### PR TITLE
fix: compilerOptions の jsx に react-jsx を指定する

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "type-check": "tsc --noEmit",
     "generate-component": "hygen generator components",
-    "build": "rimraf dist && microbundle --no-compress -f modern,esm,cjs --jsx React.createElement --jsxFragment React.Fragment --jsxImportSource react --globals react/jsx-runtime=jsx"
+    "build": "rimraf dist && microbundle --no-compress -f modern,esm,cjs"
   },
   "devDependencies": {
     "@types/react": "18.2.7",

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -2,7 +2,9 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "lib": ["dom", "esnext"],
-    "jsx": "preserve"
+    "jsx": "react-jsx",
+    "jsxFactory": "",
+    "jsxFragmentFactory": ""
   },
   "include": ["./src"]
 }

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -8,7 +8,7 @@
   "exports": "./dist/index.js",
   "scripts": {
     "generate": "node ./codegen.cjs",
-    "build": "rimraf dist && yarn generate && microbundle --no-compress -f modern,esm,cjs --jsx React.createElement --jsxFragment React.Fragment --jsxImportSource react --globals react/jsx-runtime=jsx"
+    "build": "rimraf dist && yarn generate && microbundle --no-compress -f modern,esm,cjs"
   },
   "devDependencies": {
     "cheerio": "1.0.0-rc.12",

--- a/packages/icons/tsconfig.json
+++ b/packages/icons/tsconfig.json
@@ -2,7 +2,9 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "lib": ["dom", "esnext"],
-    "jsx": "preserve"
+    "jsx": "react-jsx",
+    "jsxFactory": "",
+    "jsxFragmentFactory": ""
   },
   "include": ["./src"]
 }


### PR DESCRIPTION
## 何が解決できる
`useState` などを使用しているコンポーネントがエラーになる問題

## 何をしているか
`"jsx": "preserve"` → `"jsx": "react-jsx"`

## 詳細

このレポジトリでは `import React from 'react'` を省略していますが、
これを省略できるのは compilerOptions  の `"jsx": "react-jsx"` のときのみです。
（`"jsx": "preserve"` だと jsx がトランスパイルされないため）

毎回 `import React` を書くか `react-jsx` にするかですが、後者のほうが何かと楽だと思うので修正しました

https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html