### PR TITLE
SelectSortのラベル変更

### DIFF
--- a/packages/components/src/select-sort/select-list.tsx
+++ b/packages/components/src/select-sort/select-list.tsx
@@ -7,13 +7,12 @@ import type { SortOrder } from './type';
 type Props = {
   size: 'x-small' | 'small' | 'medium' | 'large';
   variant: 'text' | 'outline';
-  label: string;
   sortOrder: SortOrder;
   onClickItem: (value: SortOrder) => void;
   onClickDeselect?: () => void;
 };
 
-export function SelectList({ size, variant, label, sortOrder, onClickItem, onClickDeselect }: Props) {
+export function SelectList({ size, variant, sortOrder, onClickItem, onClickDeselect }: Props) {
   const listClasses = clsx(
     'z-dropdown',
     'absolute',
@@ -47,10 +46,10 @@ export function SelectList({ size, variant, label, sortOrder, onClickItem, onCli
   return (
     <ul className={listClasses}>
       <SelectItem isSortKey={sortOrder === 'ascend'} onClickItem={() => onClickItem('ascend')}>
-        {label}の昇順
+        昇順で並び替え
       </SelectItem>
       <SelectItem isSortKey={sortOrder === 'descend'} onClickItem={() => onClickItem('descend')}>
-        {label}の降順
+        降順で並び替え
       </SelectItem>
       {sortOrder !== null && onClickDeselect && (
         <li>

--- a/packages/components/src/select-sort/select-sort.tsx
+++ b/packages/components/src/select-sort/select-sort.tsx
@@ -107,7 +107,6 @@ export function SelectSort({
         <SelectList
           size={size}
           variant={variant}
-          label={label}
           sortOrder={sortOrder}
           onClickItem={handleClickItem}
           onClickDeselect={onClickDeselect}


### PR DESCRIPTION
SelectSortのラベルを「昇順で並び替え」、「降順で並び替え」に変更する

![スクリーンショット 2023-07-11 18 16 40](https://github.com/zenkigen/zenkigen-component/assets/8681045/6b522849-bb4b-42ac-a929-96174eadd917)
