### PR TITLE
Breadcrumb：テキストカラー、ホバーエフェクトの修正

### DIFF
--- a/packages/component-ui/src/breadcrumb/breadcrumb-item.tsx
+++ b/packages/component-ui/src/breadcrumb/breadcrumb-item.tsx
@@ -10,7 +10,7 @@ type Props = {
 export const BreadcrumbItem = ({ children, isLast }: Props) => {
   return (
     <>
-      <li className={clsx('[&_a]:text-interactive-interactive02')}>{children}</li>
+      <li className={clsx('[&_a]:text-interactive-interactive02', '[&_a]:hover:underline')}>{children}</li>
       {!isLast && (
         <li aria-hidden="true" className="text-interactive-interactive02">
           /

--- a/packages/component-ui/src/breadcrumb/breadcrumb.tsx
+++ b/packages/component-ui/src/breadcrumb/breadcrumb.tsx
@@ -12,7 +12,7 @@ type Props = {
 export const Breadcrumb = ({ children }: Props) => {
   return (
     <nav aria-label="breadcrumb">
-      <ul className={clsx(typography.label.label2regular, 'flex flex-wrap gap-2 whitespace-nowrap')}>
+      <ul className={clsx(typography.label.label2regular, 'flex flex-wrap gap-2 whitespace-nowrap text-text-text01')}>
         {children.map((child, i) => {
           return (
             <BreadcrumbItem key={i} isLast={i === children.length - 1}>


### PR DESCRIPTION
コンポーネント Breadcrumb の修正依頼の対応を行いました。
https://www.notion.so/zenkigen/Breadcrumb-8ccea07ccb6c4f1099fb499467f0d3b0?pvs=4

### 修正内容

- [x] 1. 標準状態のテキストカラーを修正
- [x] 2. ホバー時にアンダーラインが表示されるように修正

### 修正後のキャプチャ

#### 1.
<img width="449" alt="image" src="https://github.com/zenkigen/zenkigen-component/assets/6478212/e116abf6-8be4-49f8-9b59-adc8029a2b67">

#### 2.
<img width="303" alt="image" src="https://github.com/zenkigen/zenkigen-component/assets/6478212/167ca924-519c-4b16-b9f0-bb7e11ed6e4e">

