### PR TITLE
Dropdown：リスト要素の上下 padding サイズの修正

### DIFF
--- a/packages/component-ui/src/dropdown/dropdown-menu.tsx
+++ b/packages/component-ui/src/dropdown/dropdown-menu.tsx
@@ -32,7 +32,7 @@ export function DropdownMenu({
     horizontalAlign === 'left' ? 'left-0' : horizontalAlign === 'right' ? 'right-0' : 'left-auto',
     {
       'border-solid border border-border-uiBorder01': variant === 'outline',
-      'py-2': !isNoPadding,
+      'py-1': !isNoPadding,
     },
   );
 


### PR DESCRIPTION
コンポーネント Dropdown の修正依頼の対応を行いました。
https://www.notion.so/zenkigen/Dropdown-f7391952a930475b8d1fe3a35ba0fbca?pvs=4

### 修正内容

- [x] リスト要素の上下 padding サイズの修正

### 修正後のキャプチャ

<img width="373" alt="image" src="https://github.com/zenkigen/zenkigen-component/assets/6478212/3ef34637-6d36-4c39-8c3a-4ab6479ad481">
