### PR TITLE
fix: @storybook/addon-actions を削除

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -5,22 +5,14 @@ import turbosnap from 'vite-plugin-turbosnap';
 const config = {
   stories: ['../packages/**/*.stories.@(ts|tsx)'],
   addons: [
-    '@storybook/addon-links',
     '@storybook/addon-essentials',
     '@storybook/addon-interactions',
     '@storybook/addon-actions',
-    {
-      name: '@storybook/addon-styling',
-      options: {
-        postCss: true,
-      },
-    },
+    '@storybook/addon-styling',
   ],
   framework: {
     name: '@storybook/react-vite',
-    options: {},
   },
-  core: {},
   features: {
     storyStoreV7: true,
   },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   },
   "devDependencies": {
     "@babel/core": "7.22.10",
-    "@storybook/addon-actions": "7.2.3",
     "@storybook/addon-essentials": "7.2.3",
     "@storybook/addon-interactions": "7.2.3",
     "@storybook/addon-links": "7.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13843,7 +13843,6 @@ __metadata:
   resolution: "zenkigen-component@workspace:."
   dependencies:
     "@babel/core": 7.22.10
-    "@storybook/addon-actions": 7.2.3
     "@storybook/addon-essentials": 7.2.3
     "@storybook/addon-interactions": 7.2.3
     "@storybook/addon-links": 7.2.3


### PR DESCRIPTION
@storybook/addon-links は @storybook/addon-essentials に含まれているため削除