### PR TITLE
fix: onClickClearButton がセットされてない場合は、clear ボタンを無効（非表示）に修正

### DIFF
--- a/packages/component-ui/src/search/search.tsx
+++ b/packages/component-ui/src/search/search.tsx
@@ -55,7 +55,7 @@ export const Search = forwardRef<HTMLDivElement, Props>(({ width = '100%', size 
             placeholder={props.placeholder}
             onChange={props.onChange}
           />
-          {props.value && props.value.length !== 0 && (
+          {props.onClickClearButton && props.value && props.value.length !== 0 && (
             <IconButton
               variant="text"
               icon="close"


### PR DESCRIPTION
Search コンポーネント の修正を行いました。
https://zenkigen.slack.com/archives/C04V2HCBG4T/p1692282622891809

### 修正内容
- onClickClearButtonがない場合はclearボタンを非表示に修正
- clearボタンを出さないケースを想定する
