### PR TITLE
fix: SelectSort: iconサイズの修正

### DIFF
--- a/packages/component-ui/src/select-sort/select-sort.tsx
+++ b/packages/component-ui/src/select-sort/select-sort.tsx
@@ -89,7 +89,10 @@ export function SelectSort({
               size={size === 'large' ? 'medium' : 'small'}
             />
           ) : (
-            <Icon name={isOptionListOpen ? 'angle-small-up' : 'angle-small-down'} size="small" />
+            <Icon
+              name={isOptionListOpen ? 'angle-small-up' : 'angle-small-down'}
+              size={size === 'large' ? 'medium' : 'small'}
+            />
           )}
         </div>
       </button>


### PR DESCRIPTION
コンポーネント SelectSort の修正依頼の対応を行いました。
https://www.notion.so/zenkigen/ZENKIGEN-Component-29d4de3e60ad4e2d8e40f848ce4a253e?p=d69c04d7a326457fac9820444ceac817&pm=s

### 修正内容

- [x] Largeサイズのアイコンサイズを修正（16px → 24px）

### 修正後のキャプチャ

<img width="284" alt="image" src="https://github.com/zenkigen/zenkigen-component/assets/6478212/9c4ce957-1c75-4694-95db-5ea1d2e7e83e">
