### PR TITLE
fix: Select: iconサイズの修正

### DIFF
--- a/packages/component-ui/src/select/select.tsx
+++ b/packages/component-ui/src/select/select.tsx
@@ -105,7 +105,10 @@ export function Select({
             <div className="truncate">{selectedOption ? selectedOption.label : placeholder && placeholder}</div>
           </div>
           <div className="ml-auto flex items-center">
-            <Icon name={isOptionListOpen ? 'angle-small-up' : 'angle-small-down'} size="small" />
+            <Icon
+              name={isOptionListOpen ? 'angle-small-up' : 'angle-small-down'}
+              size={size === 'large' ? 'medium' : 'small'}
+            />
           </div>
         </button>
         {isOptionListOpen && !isDisabled && <SelectList maxHeight={optionListMaxHeight}>{children}</SelectList>}


### PR DESCRIPTION
コンポーネント SelectSort の修正依頼の対応を行いました。
https://www.notion.so/zenkigen/ZENKIGEN-Component-29d4de3e60ad4e2d8e40f848ce4a253e?p=4c3bd48756224fecaadb7b67059fb215&pm=s

### 修正内容

- [x] Largeサイズのアイコンサイズを修正（16px → 24px）

### 修正後のキャプチャ

<img width="262" alt="image" src="https://github.com/zenkigen/zenkigen-component/assets/6478212/d7cec34b-3259-47d4-9c3c-cd309c6325a1">
