### PR TITLE
Feature/Update Tokens 230920

### DIFF
--- a/packages/component-config/src/tokens/tokens.ts
+++ b/packages/component-config/src/tokens/tokens.ts
@@ -24,15 +24,15 @@ export const tokens = {
   "tokens": {
     "text": {
       "text01": "#2F3233",
-      "text02": "#838789",
-      "text03": "#7C868A",
+      "text02": "#6F7476",
+      "text03": "#838789",
       "textPlaceholder": "#CACCCD",
       "textOnColor": "#FFFFFF",
       "textBlack": "#000000",
       "text01Dark": "#FFFFFF",
       "text02Dark": "#CACCCD",
       "text03Dark": "#A4A5A6",
-      "textPlaceholderDark": "#7C868A"
+      "textPlaceholderDark": "#838789"
     },
     "link": {
       "link01": "#177EE5",
@@ -44,7 +44,7 @@ export const tokens = {
       "uiBorder01": "#DEDFE0",
       "uiBorder01Dark": "#5C6366",
       "uiBorder02": "#CACCCD",
-      "uiBorder02Dark": "#7C868A",
+      "uiBorder02Dark": "#838789",
       "uiBorder03": "#A4A5A6",
       "uiBorder03Dark": "#838789"
     },
@@ -58,7 +58,7 @@ export const tokens = {
       "uiBackgroundBlue": "#F1F7FD",
       "uiBackgroundBlueDark": "#115CA7",
       "uiBackgroundGray": "#F3F4F5",
-      "uiBackgroundGrayDark": "#7C868A",
+      "uiBackgroundGrayDark": "#838789",
       "uiBackgroundSuccess": "#ECFBF4",
       "uiBackgroundSuccessDark": "#1E8353",
       "uiBackgroundError": "#FCEFF3",
@@ -71,10 +71,10 @@ export const tokens = {
       "backgroundOverlayBlack": "#00000099"
     },
     "icon": {
-      "icon01": "#7C868A",
+      "icon01": "#6F7476",
       "icon01Dark": "#CACCCD",
       "icon02": "#A4A5A6",
-      "icon02Dark": "#7C868A",
+      "icon02Dark": "#838789",
       "icon03": "#CACCCD",
       "icon03Dark": "#5C6366",
       "iconOnColor": "#FFFFFF"
@@ -84,10 +84,10 @@ export const tokens = {
       "interactiveBg01": "#177EE5",
       "interactive01Dark": "#9FCBF5",
       "interactiveBg01Dark": "#177EE5",
-      "interactive02": "#7C868A",
+      "interactive02": "#6F7476",
       "interactive02Dark": "#CACCCD",
       "interactive03": "#177EE5",
-      "interactive03Dark": "#7C868A"
+      "interactive03Dark": "#838789"
     },
     "field": {
       "fieldInput": "#FFFFFF",
@@ -110,19 +110,19 @@ export const tokens = {
       "hoverUiDark": "#5C6366",
       "hoverUi02": "#F3F4F5",
       "hoverUi02Dark": "#454A4D",
-      "hoverUiBorder": "#7C868A",
+      "hoverUiBorder": "#6F7476",
       "hoverUiBorderDark": "#CACCCD",
       "hoverSelectedUi": "#CACCCD",
-      "hoverSelectedUiDark": "#7C868A",
+      "hoverSelectedUiDark": "#838789",
       "hoverDanger": "#B22045",
       "hoverDangerDark": "#B22045",
       "hoverError": "#B22045",
       "hoverErrorDark": "#F9E0E6",
-      "hoverInput": "#7C868A",
+      "hoverInput": "#6F7476",
       "hoverInputDark": "#A4A5A6",
       "hoverLink01": "#1366B9",
       "hoverLink01Dark": "#9FCBF5",
-      "hoverLink02": "#7C868A",
+      "hoverLink02": "#6F7476",
       "hoverLink02Dark": "#DEDFE0"
     },
     "active": {
@@ -133,7 +133,7 @@ export const tokens = {
       "active02Background": "#DEDFE0",
       "active02BackgroundDark": "#5C6366",
       "activeUi": "#D9EAFB",
-      "activeUiDark": "#7C868A",
+      "activeUiDark": "#838789",
       "activeSelectedUi": "#177EE5",
       "activeSelectedUiDark": "#177EE5",
       "activeDanger": "#821732",
@@ -149,7 +149,7 @@ export const tokens = {
       "selectedUi": "#D9EAFB",
       "selectedUiDark": "#1366B9",
       "selectedUiGray": "#DEDFE0",
-      "selectedUiGrayDark": "#7C868A",
+      "selectedUiGrayDark": "#838789",
       "selectedUiOnColor": "#FFFFFF",
       "selectedUiBorder": "#177EE5",
       "selectedUiBorderDark": "#9FCBF5"
@@ -209,7 +209,7 @@ export const tokens = {
       "gray40": "#CACCCD",
       "gray50": "#A4A5A6",
       "gray60": "#838789",
-      "gray70": "#7C868A",
+      "gray70": "#6F7476",
       "gray80": "#5C6366",
       "gray90": "#454A4D",
       "gray100": "#2F3233"

--- a/packages/component-config/style-dictionary/tokens.json
+++ b/packages/component-config/style-dictionary/tokens.json
@@ -90,12 +90,12 @@
           "description": "Primary text, Body copy, Headers"
         },
         "Text02": {
-          "value": "$Colors.Gray.Gray60",
+          "value": "$Colors.Gray.Gray70",
           "type": "color",
           "description": "Secondary text, Input labels"
         },
         "Text03": {
-          "value": "$Colors.Gray.Gray70",
+          "value": "$Colors.Gray.Gray60",
           "type": "color",
           "description": "Tertiary text"
         },
@@ -130,7 +130,7 @@
           "description": "Tertiary text - Dark"
         },
         "TextPlaceholderDark": {
-          "value": "$Colors.Gray.Gray70",
+          "value": "$Colors.Gray.Gray60",
           "type": "color",
           "description": "Placeholder text - Dark"
         }
@@ -174,7 +174,7 @@
           "description": "Button border, Input border"
         },
         "UiBorder02Dark": {
-          "value": "$Colors.Gray.Gray70",
+          "value": "$Colors.Gray.Gray60",
           "type": "color",
           "description": "Button border, Input border - Dark"
         },
@@ -236,7 +236,7 @@
           "description": "message background"
         },
         "UiBackgroundGrayDark": {
-          "value": "$Colors.Gray.Gray70",
+          "value": "$Colors.Gray.Gray60",
           "type": "color",
           "description": "message background - Dark"
         },
@@ -308,7 +308,7 @@
           "description": "Secondary icons"
         },
         "Icon02Dark": {
-          "value": "$Colors.Gray.Gray70",
+          "value": "$Colors.Gray.Gray60",
           "type": "color",
           "description": "Secondary icons - Dark"
         },
@@ -365,7 +365,7 @@
           "description": "Tertiary button, Selected elements, Active elements, Accent icon"
         },
         "Interactive03Dark": {
-          "value": "$Colors.Gray.Gray70",
+          "value": "$Colors.Gray.Gray60",
           "type": "color",
           "description": "Tertiary button, Selected elements, Active elements, Accent icon -Dark"
         }
@@ -471,7 +471,7 @@
           "description": "Checkbox border color"
         },
         "HoverSelectedUiDark": {
-          "value": "$Colors.Gray.Gray70",
+          "value": "$Colors.Gray.Gray60",
           "type": "color",
           "description": "Checkbox border color - Dark"
         },
@@ -563,7 +563,7 @@
           "description": "Active List background color"
         },
         "ActiveUiDark": {
-          "value": "$Colors.Gray.Gray70",
+          "value": "$Colors.Gray.Gray60",
           "type": "color",
           "description": "Active List background color - Dark"
         },
@@ -635,7 +635,7 @@
           "description": "Selected List Navigation Gray"
         },
         "SelectedUiGrayDark": {
-          "value": "$Colors.Gray.Gray70",
+          "value": "$Colors.Gray.Gray60",
           "type": "color",
           "description": "Selected List Navigation Gray - Dark"
         },
@@ -893,7 +893,7 @@
           "description": ""
         },
         "Gray70": {
-          "value": "#7C868A",
+          "value": "#6F7476",
           "type": "color",
           "description": ""
         },

--- a/packages/component-config/style-dictionary/transformed-tokens.json
+++ b/packages/component-config/style-dictionary/transformed-tokens.json
@@ -89,12 +89,12 @@
         "description": "Primary text, Body copy, Headers"
       },
       "Text02": {
-        "value": "#838789",
+        "value": "#6F7476",
         "type": "color",
         "description": "Secondary text, Input labels"
       },
       "Text03": {
-        "value": "#7C868A",
+        "value": "#838789",
         "type": "color",
         "description": "Tertiary text"
       },
@@ -129,7 +129,7 @@
         "description": "Tertiary text - Dark"
       },
       "TextPlaceholderDark": {
-        "value": "#7C868A",
+        "value": "#838789",
         "type": "color",
         "description": "Placeholder text - Dark"
       }
@@ -173,7 +173,7 @@
         "description": "Button border, Input border"
       },
       "UiBorder02Dark": {
-        "value": "#7C868A",
+        "value": "#838789",
         "type": "color",
         "description": "Button border, Input border - Dark"
       },
@@ -235,7 +235,7 @@
         "description": "message background"
       },
       "UiBackgroundGrayDark": {
-        "value": "#7C868A",
+        "value": "#838789",
         "type": "color",
         "description": "message background - Dark"
       },
@@ -292,7 +292,7 @@
     },
     "Icon": {
       "Icon01": {
-        "value": "#7C868A",
+        "value": "#6F7476",
         "type": "color",
         "description": "Primary icons"
       },
@@ -307,7 +307,7 @@
         "description": "Secondary icons"
       },
       "Icon02Dark": {
-        "value": "#7C868A",
+        "value": "#838789",
         "type": "color",
         "description": "Secondary icons - Dark"
       },
@@ -349,7 +349,7 @@
         "description": "Primary Interactive color on background, Primary fill buttons - Dark"
       },
       "Interactive02": {
-        "value": "#7C868A",
+        "value": "#6F7476",
         "type": "color",
         "description": "Secondary Interactive color, Secondary buttons"
       },
@@ -364,7 +364,7 @@
         "description": "Tertiary button, Selected elements, Active elements, Accent icon"
       },
       "Interactive03Dark": {
-        "value": "#7C868A",
+        "value": "#838789",
         "type": "color",
         "description": "Tertiary button, Selected elements, Active elements, Accent icon -Dark"
       }
@@ -455,7 +455,7 @@
         "description": "hover ui background with darker color"
       },
       "HoverUiBorder": {
-        "value": "#7C868A",
+        "value": "#6F7476",
         "type": "color",
         "description": "hover ui background - Dark"
       },
@@ -470,7 +470,7 @@
         "description": "Checkbox border color"
       },
       "HoverSelectedUiDark": {
-        "value": "#7C868A",
+        "value": "#838789",
         "type": "color",
         "description": "Checkbox border color - Dark"
       },
@@ -495,7 +495,7 @@
         "description": "Error hover - Dark"
       },
       "HoverInput": {
-        "value": "#7C868A",
+        "value": "#6F7476",
         "type": "color",
         "description": "hover input"
       },
@@ -515,7 +515,7 @@
         "description": "hover primary link - Dark"
       },
       "HoverLink02": {
-        "value": "#7C868A",
+        "value": "#6F7476",
         "type": "color",
         "description": "hover secondary link"
       },
@@ -562,7 +562,7 @@
         "description": "Active List background color"
       },
       "ActiveUiDark": {
-        "value": "#7C868A",
+        "value": "#838789",
         "type": "color",
         "description": "Active List background color - Dark"
       },
@@ -634,7 +634,7 @@
         "description": "Selected List Navigation Gray"
       },
       "SelectedUiGrayDark": {
-        "value": "#7C868A",
+        "value": "#838789",
         "type": "color",
         "description": "Selected List Navigation Gray - Dark"
       },
@@ -892,7 +892,7 @@
         "description": ""
       },
       "Gray70": {
-        "value": "#7C868A",
+        "value": "#6F7476",
         "type": "color",
         "description": ""
       },


### PR DESCRIPTION
アクセシビリティ向上のためGray70を更新したカラートークンを適用するPRです。
- 従来のGray70を新色（#6F7476）に更新（コントラスト比を確保する）
- Gray70が割り当てられていたセマンティックトークンを新色にし、Text02：Gray70、Text03：Gray60とする。
- ダークモードでは、Gray70が割り当てられていたセマンティックトークンをGray60に変更。
- 平塚さんがリストアップしてくれた更新内容
- [[アクセシビリティリサーチ](https://www.notion.so/e00af43b476745cd8cd2c279a3ec9499?pvs=21)](https://www.notion.so/e00af43b476745cd8cd2c279a3ec9499?pvs=21)

既存のzenkigen-compoentへの影響確認
- 更新したトークンの出現箇所をリストアップして視認性を確認し、特に問題ないと判断しています。
https://www.notion.so/zenkigen/UIUX-0c5dcdabdf704d43a63d35843386fd1b?p=fb1bcec5acd4412686dbc33eefc85b31&pm=s