### PR TITLE
refactor: Select 再選択時に選択済み要素が表示領域に配置されるよう調整

### DIFF
--- a/packages/component-ui/src/select/select-item.tsx
+++ b/packages/component-ui/src/select/select-item.tsx
@@ -12,12 +12,11 @@ type Props = {
 
 export function SelectItem({ option }: Props) {
   const { setIsOptionListOpen, selectedOption, onChange } = useContext(SelectContext);
+
   const handleClickItem = (option: SelectOption) => {
     onChange?.(option);
     setIsOptionListOpen(false);
   };
-
-  const listItemClasses = clsx('flex w-full items-center');
 
   const itemClasses = clsx(
     'flex',
@@ -37,7 +36,7 @@ export function SelectItem({ option }: Props) {
   );
 
   return (
-    <li className={listItemClasses} key={option.id} data-id={option.id}>
+    <li className="flex w-full items-center" key={option.id} data-id={option.id}>
       <button className={itemClasses} type="button" onClick={() => handleClickItem(option)}>
         {option.icon && <Icon name={option.icon} size="small" />}
         <span className="ml-1 mr-6">{option.label}</span>

--- a/packages/component-ui/src/select/select-item.tsx
+++ b/packages/component-ui/src/select/select-item.tsx
@@ -37,7 +37,7 @@ export function SelectItem({ option }: Props) {
   );
 
   return (
-    <li className={listItemClasses} key={option.id}>
+    <li className={listItemClasses} key={option.id} data-id={option.id}>
       <button className={itemClasses} type="button" onClick={() => handleClickItem(option)}>
         {option.icon && <Icon name={option.icon} size="small" />}
         <span className="ml-1 mr-6">{option.label}</span>

--- a/packages/component-ui/src/select/select-list.tsx
+++ b/packages/component-ui/src/select/select-list.tsx
@@ -1,6 +1,6 @@
 import { focusVisible, typography } from '@zenkigen-inc/component-theme';
 import clsx from 'clsx';
-import { CSSProperties, PropsWithChildren, useContext, useEffect, useRef } from 'react';
+import { CSSProperties, PropsWithChildren, useContext, useLayoutEffect, useRef } from 'react';
 
 import { SelectContext } from './select-context';
 
@@ -17,15 +17,15 @@ export function SelectList({ children, maxHeight }: PropsWithChildren<Props>) {
     setIsOptionListOpen(false);
   };
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (maxHeight && ref.current) {
-      const element = Array.from(ref.current?.children || []).find(
+      const element = Array.from(ref.current.children || []).find(
         (item) => item.getAttribute('data-id') === selectedOption?.id,
       );
       if (element) {
         const wrapRect = ref.current.getBoundingClientRect();
         const rect = element.getBoundingClientRect();
-        ref.current?.scroll(0, rect.top - wrapRect.top - wrapRect.height / 2 + rect.height / 2);
+        ref.current.scroll(0, rect.top - wrapRect.top - wrapRect.height / 2 + rect.height / 2);
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/component-ui/src/select/select-list.tsx
+++ b/packages/component-ui/src/select/select-list.tsx
@@ -9,7 +9,7 @@ type Props = {
 };
 
 export function SelectList({ children, maxHeight }: PropsWithChildren<Props>) {
-  const ulistRef = useRef<HTMLUListElement>(null);
+  const ref = useRef<HTMLUListElement>(null);
   const { size, selectedOption, setIsOptionListOpen, variant, placeholder, onChange } = useContext(SelectContext);
 
   const handleClickDeselect = () => {
@@ -17,11 +17,19 @@ export function SelectList({ children, maxHeight }: PropsWithChildren<Props>) {
     setIsOptionListOpen(false);
   };
 
-  useEffect(()=>{
-    // TODO:
-    // - 選択済み要素の位置を計算しscrollする
-    ulistRef.current?.scroll(0, 100)
-  }, [])
+  useEffect(() => {
+    if (maxHeight && ref.current) {
+      const element = Array.from(ref.current?.children || []).find(
+        (item) => item.getAttribute('data-id') === selectedOption?.id,
+      );
+      if (element) {
+        const wrapRect = ref.current.getBoundingClientRect();
+        const rect = element.getBoundingClientRect();
+        ref.current?.scroll(0, rect.top - wrapRect.top - wrapRect.height / 2 + rect.height / 2);
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const listClasses = clsx(
     'z-dropdown',
@@ -54,7 +62,7 @@ export function SelectList({ children, maxHeight }: PropsWithChildren<Props>) {
   );
 
   return (
-    <ul className={listClasses} style={{ maxHeight }} ref={ulistRef}>
+    <ul className={listClasses} style={{ maxHeight }} ref={ref}>
       {children}
       {placeholder && selectedOption !== null && (
         <li>

--- a/packages/component-ui/src/select/select-list.tsx
+++ b/packages/component-ui/src/select/select-list.tsx
@@ -1,6 +1,6 @@
 import { focusVisible, typography } from '@zenkigen-inc/component-theme';
 import clsx from 'clsx';
-import { CSSProperties, PropsWithChildren, useContext } from 'react';
+import { CSSProperties, PropsWithChildren, useContext, useEffect, useRef } from 'react';
 
 import { SelectContext } from './select-context';
 
@@ -9,12 +9,19 @@ type Props = {
 };
 
 export function SelectList({ children, maxHeight }: PropsWithChildren<Props>) {
+  const ulistRef = useRef<HTMLUListElement>(null);
   const { size, selectedOption, setIsOptionListOpen, variant, placeholder, onChange } = useContext(SelectContext);
 
   const handleClickDeselect = () => {
     onChange?.(null);
     setIsOptionListOpen(false);
   };
+
+  useEffect(()=>{
+    // TODO:
+    // - 選択済み要素の位置を計算しscrollする
+    ulistRef.current?.scroll(0, 100)
+  }, [])
 
   const listClasses = clsx(
     'z-dropdown',
@@ -47,7 +54,7 @@ export function SelectList({ children, maxHeight }: PropsWithChildren<Props>) {
   );
 
   return (
-    <ul className={listClasses} style={{ maxHeight }}>
+    <ul className={listClasses} style={{ maxHeight }} ref={ulistRef}>
       {children}
       {placeholder && selectedOption !== null && (
         <li>


### PR DESCRIPTION
Select コンポーネントの改善を行いました。

### 対応内容
- 再選択時に、選択済み要素が表示領域外にあり選択状態が不明な状態となっていたのを改善

### 改善内容
maxHeight の指定がある場合に、以下となるよう対応した。

- [x] リストの再選択時に選択済み要素が表示領域に配置されるよう調整
- [x] その際にリスト縦中央に位置するよう調整した

### キャプチャ
| Before | After |
| --- | --- |
| <img width="187" alt="image" src="https://github.com/zenkigen/zenkigen-component/assets/6478212/4b0b3eb1-5612-448f-9a8d-5163290b3574"> | <img width="182" alt="image" src="https://github.com/zenkigen/zenkigen-component/assets/6478212/22c9cb32-4404-4624-9a1e-81169a0f2201"> |
