### PR TITLE
feat: Dropdown リスト部分を自由な位置に表示できるよう調整

### DIFF
--- a/packages/component-ui/src/dropdown/dropdown-context.ts
+++ b/packages/component-ui/src/dropdown/dropdown-context.ts
@@ -1,4 +1,4 @@
-import { createContext,MutableRefObject } from 'react';
+import { createContext, MutableRefObject } from 'react';
 
 type UseDropdownReturnType = {
   isVisible: boolean;

--- a/packages/component-ui/src/dropdown/dropdown-context.ts
+++ b/packages/component-ui/src/dropdown/dropdown-context.ts
@@ -1,9 +1,10 @@
-import { createContext } from 'react';
+import { createContext,MutableRefObject } from 'react';
 
 type UseDropdownReturnType = {
   isVisible: boolean;
   setIsVisible: React.Dispatch<React.SetStateAction<boolean>>;
   isDisabled: boolean;
+  portalTargetRef?: MutableRefObject<HTMLElement | null>;
   targetDimensions: {
     width: number;
     height: number;

--- a/packages/component-ui/src/dropdown/dropdown-menu.tsx
+++ b/packages/component-ui/src/dropdown/dropdown-menu.tsx
@@ -28,7 +28,7 @@ export function DropdownMenu({
     'overflow-y-auto',
     horizontalAlign === 'left' ? 'left-0' : horizontalAlign === 'right' ? 'right-0' : 'left-auto',
     {
-      'absolute': !portalTargetRef,
+      absolute: !portalTargetRef,
       'border-solid border border-border-uiBorder01': variant === 'outline',
       'py-1': !isNoPadding,
     },

--- a/packages/component-ui/src/dropdown/dropdown-menu.tsx
+++ b/packages/component-ui/src/dropdown/dropdown-menu.tsx
@@ -18,10 +18,9 @@ export function DropdownMenu({
   verticalPosition = 'bottom',
   horizontalAlign = 'left',
 }: PropsWithChildren<Props>) {
-  const { isVisible, isDisabled, targetDimensions, variant } = useContext(DropdownContext);
+  const { isVisible, isDisabled, targetDimensions, variant, portalTargetRef } = useContext(DropdownContext);
   const wrapperClasses = clsx(
     'z-dropdown',
-    'absolute',
     'w-max',
     'bg-background-uiBackground01',
     'rounded',
@@ -29,6 +28,7 @@ export function DropdownMenu({
     'overflow-y-auto',
     horizontalAlign === 'left' ? 'left-0' : horizontalAlign === 'right' ? 'right-0' : 'left-auto',
     {
+      'absolute': !portalTargetRef,
       'border-solid border border-border-uiBorder01': variant === 'outline',
       'py-1': !isNoPadding,
     },
@@ -40,8 +40,8 @@ export function DropdownMenu({
       <ul
         className={wrapperClasses}
         style={{
-          top: verticalPosition === 'bottom' ? `${targetDimensions.height + 4}px` : 'unset',
-          bottom: verticalPosition === 'top' ? `${targetDimensions.height + 4}px` : 'unset',
+          top: !portalTargetRef && verticalPosition === 'bottom' ? `${targetDimensions.height + 4}px` : 'unset',
+          bottom: !portalTargetRef && verticalPosition === 'top' ? `${targetDimensions.height + 4}px` : 'unset',
           maxHeight,
         }}
       >

--- a/packages/component-ui/src/dropdown/dropdown.stories.tsx
+++ b/packages/component-ui/src/dropdown/dropdown.stories.tsx
@@ -433,10 +433,10 @@ const DropdownWithCustomMenu = () => {
       onChange: () => setIsOn5((prev) => !prev),
     },
   ];
-  
-return (
+
+  return (
     <div style={{ display: 'flex', alignItems: 'center', margin: '60px 100px' }}>
-      <Dropdown size="medium" label="フィルター" icon="filter" >
+      <Dropdown size="medium" label="フィルター" icon="filter">
         <Dropdown.Menu horizontalAlign="left" isNoPadding>
           <ul className="flex w-[208px] flex-col gap-y-2.5 px-4 py-3">
             {items.map((item) => (
@@ -475,87 +475,90 @@ export const WithCustomMenu: Story = {
   render: () => <DropdownWithCustomMenu />,
 };
 
-const DropdownMenuContainer = forwardRef<HTMLDivElement, PropsWithChildren>(
-  ({ children }: PropsWithChildren, ref) => {
-    const classes = clsx(
-      'absolute',
-      'top-10',
-      'left-10',
-    );
-    
-    return (
-      <div className={classes} ref={ref}>{children}</div>
-    );
-  },
-);
-DropdownMenuContainer.displayName = 'DropdownMenuContainer';
+const DropdownMenuContainer = forwardRef<HTMLDivElement, PropsWithChildren>(({ children }: PropsWithChildren, ref) => {
+  const classes = clsx('absolute', 'top-10', 'left-10');
 
+  return (
+    <div className={classes} ref={ref}>
+      {children}
+    </div>
+  );
+});
+DropdownMenuContainer.displayName = 'DropdownMenuContainer';
 
 const DropdownWithPortal = () => {
   const containerRef = useRef<HTMLDivElement>(null);
 
   return (
     <div>
-      <div style={{ display: 'flex', alignItems: "center", justifyContent: "center", height: "100vh"}}>
-        <div style={{ display: 'flex', flexDirection: 'row', gap: "100px"}}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100vh' }}>
+        <div style={{ display: 'flex', flexDirection: 'row', gap: '100px' }}>
           <div>
-            <Dropdown size="large" target={<Avatar size="medium" userId={1} lastName="全機現" firstName="太郎" />} portalTargetRef={containerRef}>
-                <Dropdown.Menu>
-                  {items.map((item) => (
-                    <Dropdown.Item key={item.id} onClick={item.onClick}>
-                      {item.content}
-                    </Dropdown.Item>
-                  ))}
-                </Dropdown.Menu>
+            <Dropdown
+              size="large"
+              target={<Avatar size="medium" userId={1} lastName="全機現" firstName="太郎" />}
+              portalTargetRef={containerRef}
+            >
+              <Dropdown.Menu>
+                {items.map((item) => (
+                  <Dropdown.Item key={item.id} onClick={item.onClick}>
+                    {item.content}
+                  </Dropdown.Item>
+                ))}
+              </Dropdown.Menu>
             </Dropdown>
           </div>
           <div>
-            <Dropdown size="medium" target={<Icon name="more" size="large" color="icon01" />} portalTargetRef={containerRef}>
-                <Dropdown.Menu>
-                  {items.map((item) => (
-                    <Dropdown.Item key={item.id} onClick={item.onClick}>
-                      {item.content}
-                    </Dropdown.Item>
-                  ))}
-                </Dropdown.Menu>
+            <Dropdown
+              size="medium"
+              target={<Icon name="more" size="large" color="icon01" />}
+              portalTargetRef={containerRef}
+            >
+              <Dropdown.Menu>
+                {items.map((item) => (
+                  <Dropdown.Item key={item.id} onClick={item.onClick}>
+                    {item.content}
+                  </Dropdown.Item>
+                ))}
+              </Dropdown.Menu>
             </Dropdown>
           </div>
           <div>
             <Dropdown size="large" label="選択" portalTargetRef={containerRef}>
-                <Dropdown.Menu horizontalAlign="left">
-                  {items2.map((item) => (
-                    <Dropdown.Item key={item.id} onClick={item.onClick}>
-                      {item.content}
-                    </Dropdown.Item>
-                  ))}
-                </Dropdown.Menu>
+              <Dropdown.Menu horizontalAlign="left">
+                {items2.map((item) => (
+                  <Dropdown.Item key={item.id} onClick={item.onClick}>
+                    {item.content}
+                  </Dropdown.Item>
+                ))}
+              </Dropdown.Menu>
             </Dropdown>
           </div>
           <div>
             <Dropdown size="large" label="選択" icon="add" portalTargetRef={containerRef}>
-                <Dropdown.Menu horizontalAlign="left">
-                  {items2.map((item) => (
-                    <Dropdown.Item key={item.id} onClick={item.onClick}>
-                      {item.content}
-                    </Dropdown.Item>
-                  ))}
-                </Dropdown.Menu>
+              <Dropdown.Menu horizontalAlign="left">
+                {items2.map((item) => (
+                  <Dropdown.Item key={item.id} onClick={item.onClick}>
+                    {item.content}
+                  </Dropdown.Item>
+                ))}
+              </Dropdown.Menu>
             </Dropdown>
           </div>
           <div>
             <Dropdown size="large" label="選択" icon="add" isArrowHidden portalTargetRef={containerRef}>
-                <Dropdown.Menu horizontalAlign="left">
-                  {items2.map((item) => (
-                    <Dropdown.Item key={item.id} onClick={item.onClick}>
-                      {item.content}
-                    </Dropdown.Item>
-                  ))}
-                </Dropdown.Menu>
+              <Dropdown.Menu horizontalAlign="left">
+                {items2.map((item) => (
+                  <Dropdown.Item key={item.id} onClick={item.onClick}>
+                    {item.content}
+                  </Dropdown.Item>
+                ))}
+              </Dropdown.Menu>
             </Dropdown>
           </div>
         </div>
       </div>
-      <DropdownMenuContainer ref={containerRef}/>
+      <DropdownMenuContainer ref={containerRef} />
     </div>
   );
 };

--- a/packages/component-ui/src/dropdown/dropdown.stories.tsx
+++ b/packages/component-ui/src/dropdown/dropdown.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { IconName } from '@zenkigen-inc/component-icons';
 import { typography } from '@zenkigen-inc/component-theme';
 import clsx from 'clsx';
-import { useState } from 'react';
+import { forwardRef, PropsWithChildren, useRef, useState } from 'react';
 
 import { Avatar } from '../avatar';
 import { Button } from '../button';
@@ -433,10 +433,10 @@ const DropdownWithCustomMenu = () => {
       onChange: () => setIsOn5((prev) => !prev),
     },
   ];
-
-  return (
+  
+return (
     <div style={{ display: 'flex', alignItems: 'center', margin: '60px 100px' }}>
-      <Dropdown size="medium" label="フィルター" icon="filter">
+      <Dropdown size="medium" label="フィルター" icon="filter" >
         <Dropdown.Menu horizontalAlign="left" isNoPadding>
           <ul className="flex w-[208px] flex-col gap-y-2.5 px-4 py-3">
             {items.map((item) => (
@@ -473,4 +473,93 @@ const DropdownWithCustomMenu = () => {
 
 export const WithCustomMenu: Story = {
   render: () => <DropdownWithCustomMenu />,
+};
+
+const DropdownMenuContainer = forwardRef<HTMLDivElement, PropsWithChildren>(
+  ({ children }: PropsWithChildren, ref) => {
+    const classes = clsx(
+      'absolute',
+      'top-10',
+      'left-10',
+    );
+    
+    return (
+      <div className={classes} ref={ref}>{children}</div>
+    );
+  },
+);
+DropdownMenuContainer.displayName = 'DropdownMenuContainer';
+
+
+const DropdownWithPortal = () => {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  return (
+    <div>
+      <div style={{ display: 'flex', alignItems: "center", justifyContent: "center", height: "100vh"}}>
+        <div style={{ display: 'flex', flexDirection: 'row', gap: "100px"}}>
+          <div>
+            <Dropdown size="large" target={<Avatar size="medium" userId={1} lastName="全機現" firstName="太郎" />} portalTargetRef={containerRef}>
+                <Dropdown.Menu>
+                  {items.map((item) => (
+                    <Dropdown.Item key={item.id} onClick={item.onClick}>
+                      {item.content}
+                    </Dropdown.Item>
+                  ))}
+                </Dropdown.Menu>
+            </Dropdown>
+          </div>
+          <div>
+            <Dropdown size="medium" target={<Icon name="more" size="large" color="icon01" />} portalTargetRef={containerRef}>
+                <Dropdown.Menu>
+                  {items.map((item) => (
+                    <Dropdown.Item key={item.id} onClick={item.onClick}>
+                      {item.content}
+                    </Dropdown.Item>
+                  ))}
+                </Dropdown.Menu>
+            </Dropdown>
+          </div>
+          <div>
+            <Dropdown size="large" label="選択" portalTargetRef={containerRef}>
+                <Dropdown.Menu horizontalAlign="left">
+                  {items2.map((item) => (
+                    <Dropdown.Item key={item.id} onClick={item.onClick}>
+                      {item.content}
+                    </Dropdown.Item>
+                  ))}
+                </Dropdown.Menu>
+            </Dropdown>
+          </div>
+          <div>
+            <Dropdown size="large" label="選択" icon="add" portalTargetRef={containerRef}>
+                <Dropdown.Menu horizontalAlign="left">
+                  {items2.map((item) => (
+                    <Dropdown.Item key={item.id} onClick={item.onClick}>
+                      {item.content}
+                    </Dropdown.Item>
+                  ))}
+                </Dropdown.Menu>
+            </Dropdown>
+          </div>
+          <div>
+            <Dropdown size="large" label="選択" icon="add" isArrowHidden portalTargetRef={containerRef}>
+                <Dropdown.Menu horizontalAlign="left">
+                  {items2.map((item) => (
+                    <Dropdown.Item key={item.id} onClick={item.onClick}>
+                      {item.content}
+                    </Dropdown.Item>
+                  ))}
+                </Dropdown.Menu>
+            </Dropdown>
+          </div>
+        </div>
+      </div>
+      <DropdownMenuContainer ref={containerRef}/>
+    </div>
+  );
+};
+
+export const WithPortal: Story = {
+  render: () => <DropdownWithPortal />,
 };

--- a/packages/component-ui/src/dropdown/dropdown.tsx
+++ b/packages/component-ui/src/dropdown/dropdown.tsx
@@ -112,7 +112,9 @@ export function Dropdown({
   );
 
   return (
-    <DropdownContext.Provider value={{ isVisible, setIsVisible, isDisabled, targetDimensions, variant, portalTargetRef }}>
+    <DropdownContext.Provider
+      value={{ isVisible, setIsVisible, isDisabled, targetDimensions, variant, portalTargetRef }}
+    >
       <div ref={targetRef} className={wrapperClasses}>
         {target ? (
           <button
@@ -139,7 +141,9 @@ export function Dropdown({
             )}
           </button>
         )}
-        {!portalTargetRef ? children : portalTargetRef && portalTargetRef.current && createPortal(children, portalTargetRef.current)}
+        {!portalTargetRef
+          ? children
+          : portalTargetRef && portalTargetRef.current && createPortal(children, portalTargetRef.current)}
       </div>
     </DropdownContext.Provider>
   );

--- a/packages/component-ui/src/dropdown/dropdown.tsx
+++ b/packages/component-ui/src/dropdown/dropdown.tsx
@@ -1,7 +1,8 @@
 import { IconName } from '@zenkigen-inc/component-icons';
 import { buttonColors, focusVisible, typography } from '@zenkigen-inc/component-theme';
 import clsx from 'clsx';
-import { PropsWithChildren, ReactElement, useCallback, useRef, useState } from 'react';
+import { MutableRefObject, PropsWithChildren, ReactElement, useCallback, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 
 import { useOutsideClick } from '../hooks/use-outside-click';
 import { Icon } from '../icon';
@@ -15,6 +16,7 @@ type Props = {
   title?: string;
   isDisabled?: boolean;
   isArrowHidden?: boolean;
+  portalTargetRef?: MutableRefObject<HTMLElement | null>;
 } & (
   | { target: ReactElement; label?: never; icon?: never }
   | {
@@ -34,6 +36,7 @@ export function Dropdown({
   title,
   isDisabled = false,
   isArrowHidden = false,
+  portalTargetRef,
 }: PropsWithChildren<Props>) {
   const [isVisible, setIsVisible] = useState(false);
   const [targetDimensions, setTargetDimensions] = useState({
@@ -109,7 +112,7 @@ export function Dropdown({
   );
 
   return (
-    <DropdownContext.Provider value={{ isVisible, setIsVisible, isDisabled, targetDimensions, variant }}>
+    <DropdownContext.Provider value={{ isVisible, setIsVisible, isDisabled, targetDimensions, variant, portalTargetRef }}>
       <div ref={targetRef} className={wrapperClasses}>
         {target ? (
           <button
@@ -136,7 +139,7 @@ export function Dropdown({
             )}
           </button>
         )}
-        {children}
+        {!portalTargetRef ? children : portalTargetRef && portalTargetRef.current && createPortal(children, portalTargetRef.current)}
       </div>
     </DropdownContext.Provider>
   );


### PR DESCRIPTION
Dropdown コンポーネントの改善を行いました。

### 対応内容
- リスト部分を自由な位置に表示できるよう調整した

### 改善内容
- [x] prop portalTargetRef を新設し、渡された場合に表示をそちらに渡すよう対応した

### キャプチャ
| Before | After |
| --- | --- |
|  | <img width="970" alt="image" src="https://github.com/zenkigen/zenkigen-component/assets/6478212/949df262-4131-4f2f-8262-e0a1e89027d9"> |
