### PR TITLE
feat: modal: closeボタンクリック時の制御方法の変更

### DIFF
--- a/packages/component-ui/src/modal/modal-context.ts
+++ b/packages/component-ui/src/modal/modal-context.ts
@@ -1,9 +1,0 @@
-import { createContext } from 'react';
-
-type ModalReturnType = {
-  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
-};
-
-export const ModalContext = createContext<ModalReturnType>({
-  setIsOpen: () => false,
-});

--- a/packages/component-ui/src/modal/modal-context.ts
+++ b/packages/component-ui/src/modal/modal-context.ts
@@ -1,9 +1,9 @@
 import { createContext } from 'react';
 
 type ModalReturnType = {
-  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  onClose: () => void;
 };
 
 export const ModalContext = createContext<ModalReturnType>({
-  setIsOpen: () => false,
+  onClose: () => null,
 });

--- a/packages/component-ui/src/modal/modal-context.ts
+++ b/packages/component-ui/src/modal/modal-context.ts
@@ -1,0 +1,9 @@
+import { createContext } from 'react';
+
+type ModalReturnType = {
+  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
+export const ModalContext = createContext<ModalReturnType>({
+  setIsOpen: () => false,
+});

--- a/packages/component-ui/src/modal/modal-header.tsx
+++ b/packages/component-ui/src/modal/modal-header.tsx
@@ -1,27 +1,29 @@
 import clsx from 'clsx';
-import { PropsWithChildren } from 'react';
+import { PropsWithChildren, useContext } from 'react';
 
 import { IconButton } from '../icon-button';
+import { ModalContext } from './modal-context';
 
 type Props = {
   isNoBorder?: boolean;
-  onClickClose?: () => void;
+  isNoCloseButton?: boolean;
 };
 
-export function ModalHeader({ children, isNoBorder, onClickClose }: PropsWithChildren<Props>) {
+export function ModalHeader({ children, isNoBorder, isNoCloseButton }: PropsWithChildren<Props>) {
+  const { setIsOpen } = useContext(ModalContext);
   const headerClasses = clsx(
     'typography-h5 flex w-full shrink-0 items-center justify-between rounded-t-lg px-6 text-text-text01',
     {
       'border-b-[1px] border-border-uiBorder01': !isNoBorder,
-      'h-14': onClickClose,
-      'h-12': !onClickClose,
+      'h-14': !isNoCloseButton,
+      'h-12': isNoCloseButton,
     },
   );
 
   return (
     <div className={headerClasses}>
       <div>{children}</div>
-      {onClickClose && <IconButton icon="close" size="small" variant="text" onClick={onClickClose} />}
+      {!isNoCloseButton && <IconButton icon="close" size="small" variant="text" onClick={() => setIsOpen(false)} />}
     </div>
   );
 }

--- a/packages/component-ui/src/modal/modal-header.tsx
+++ b/packages/component-ui/src/modal/modal-header.tsx
@@ -1,29 +1,27 @@
 import clsx from 'clsx';
-import { PropsWithChildren, useContext } from 'react';
+import { PropsWithChildren } from 'react';
 
 import { IconButton } from '../icon-button';
-import { ModalContext } from './modal-context';
 
 type Props = {
   isNoBorder?: boolean;
-  isNoCloseButton?: boolean;
+  onClickClose?: () => void;
 };
 
-export function ModalHeader({ children, isNoBorder, isNoCloseButton }: PropsWithChildren<Props>) {
-  const { setIsOpen } = useContext(ModalContext);
+export function ModalHeader({ children, isNoBorder, onClickClose }: PropsWithChildren<Props>) {
   const headerClasses = clsx(
     'typography-h5 flex w-full shrink-0 items-center justify-between rounded-t-lg px-6 text-text-text01',
     {
       'border-b-[1px] border-border-uiBorder01': !isNoBorder,
-      'h-14': !isNoCloseButton,
-      'h-12': isNoCloseButton,
+      'h-14': onClickClose,
+      'h-12': !onClickClose,
     },
   );
 
   return (
     <div className={headerClasses}>
       <div>{children}</div>
-      {!isNoCloseButton && <IconButton icon="close" size="small" variant="text" onClick={() => setIsOpen(false)} />}
+      {onClickClose && <IconButton icon="close" size="small" variant="text" onClick={onClickClose} />}
     </div>
   );
 }

--- a/packages/component-ui/src/modal/modal-header.tsx
+++ b/packages/component-ui/src/modal/modal-header.tsx
@@ -10,7 +10,7 @@ type Props = {
 };
 
 export function ModalHeader({ children, isNoBorder, isNoCloseButton }: PropsWithChildren<Props>) {
-  const { setIsOpen } = useContext(ModalContext);
+  const { onClose } = useContext(ModalContext);
   const headerClasses = clsx(
     'typography-h5 flex w-full shrink-0 items-center justify-between rounded-t-lg px-6 text-text-text01',
     {
@@ -23,7 +23,7 @@ export function ModalHeader({ children, isNoBorder, isNoCloseButton }: PropsWith
   return (
     <div className={headerClasses}>
       <div>{children}</div>
-      {!isNoCloseButton && <IconButton icon="close" size="small" variant="text" onClick={() => setIsOpen(false)} />}
+      {!isNoCloseButton && <IconButton icon="close" size="small" variant="text" onClick={() => onClose()} />}
     </div>
   );
 }

--- a/packages/component-ui/src/modal/modal.stories.tsx
+++ b/packages/component-ui/src/modal/modal.stories.tsx
@@ -20,15 +20,15 @@ export const Base: Story = {
     width: 480,
   },
   render: function MyFunc({ ...args }) {
-    const [isOpen, setIsOpen] = useState(true);
+    const [, setIsOpen] = useState(false);
 
     return (
       <div>
         <button type="button" onClick={() => setIsOpen(true)}>
           open
         </button>
-        <Modal isOpen={isOpen} width={args.width}>
-          <Modal.Header onClickClose={() => setIsOpen(false)}>タイトル</Modal.Header>
+        <Modal isOpen setIsOpen={setIsOpen} width={args.width}>
+          <Modal.Header>タイトル</Modal.Header>
           <Modal.Body>
             <div className="flex h-[200px] w-full items-center justify-center">Content</div>
           </Modal.Body>
@@ -53,7 +53,7 @@ export const WithCheckbox: Story = {
     width: 480,
   },
   render: function MyFunc({ ...args }) {
-    const [isOpen, setIsOpen] = useState(true);
+    const [, setIsOpen] = useState(false);
     const [isChecked, setIsChecked] = useState(false);
 
     return (
@@ -61,8 +61,8 @@ export const WithCheckbox: Story = {
         <button type="button" onClick={() => setIsOpen(true)}>
           open
         </button>
-        <Modal isOpen={isOpen} width={args.width}>
-          <Modal.Header onClickClose={() => setIsOpen(false)}>タイトル</Modal.Header>
+        <Modal isOpen setIsOpen={setIsOpen} width={args.width}>
+          <Modal.Header>タイトル</Modal.Header>
           <Modal.Body>
             <div className="flex h-[200px] w-full items-center justify-center">Content</div>
           </Modal.Body>
@@ -97,15 +97,15 @@ export const WithSubButton: Story = {
     width: 480,
   },
   render: function MyFunc({ ...args }) {
-    const [isOpen, setIsOpen] = useState(true);
+    const [, setIsOpen] = useState(false);
 
     return (
       <div>
         <button type="button" onClick={() => setIsOpen(true)}>
           open
         </button>
-        <Modal isOpen={isOpen} width={args.width}>
-          <Modal.Header onClickClose={() => setIsOpen(false)}>タイトル</Modal.Header>
+        <Modal isOpen setIsOpen={setIsOpen} width={args.width}>
+          <Modal.Header>タイトル</Modal.Header>
           <Modal.Body>
             <div className="flex h-[200px] w-full items-center justify-center">Content</div>
           </Modal.Body>
@@ -137,15 +137,15 @@ export const FixedHeight: Story = {
     width: 480,
   },
   render: function MyFunc({ ...args }) {
-    const [isOpen, setIsOpen] = useState(true);
+    const [, setIsOpen] = useState(false);
 
     return (
       <div>
         <button type="button" onClick={() => setIsOpen(true)}>
           open
         </button>
-        <Modal isOpen={isOpen} width={args.width} height={500}>
-          <Modal.Header onClickClose={() => setIsOpen(false)}>タイトル</Modal.Header>
+        <Modal isOpen setIsOpen={setIsOpen} width={args.width} height={500}>
+          <Modal.Header>タイトル</Modal.Header>
           <Modal.Body>
             <div className="flex h-[800px] w-full items-center justify-center">Content</div>
           </Modal.Body>
@@ -170,7 +170,7 @@ export const WithTabs: Story = {
     width: 480,
   },
   render: function MyFunc({ ...args }) {
-    const [isOpen, setIsOpen] = useState(true);
+    const [, setIsOpen] = useState(false);
     const [selectedTab, setSelectedTab] = useState('tab1');
     const tabItems = [
       { id: 'tab1', label: 'タブラベル1' },
@@ -183,8 +183,8 @@ export const WithTabs: Story = {
         <button type="button" onClick={() => setIsOpen(true)}>
           open
         </button>
-        <Modal isOpen={isOpen} width={args.width}>
-          <Modal.Header onClickClose={() => setIsOpen(false)}>タイトル</Modal.Header>
+        <Modal isOpen setIsOpen={setIsOpen} width={args.width}>
+          <Modal.Header isNoBorder>タイトル</Modal.Header>
           <Modal.Body>
             <div className="mt-2 flex w-full flex-col">
               <div className="w-full">
@@ -224,15 +224,15 @@ export const WithoutButton: Story = {
     width: 480,
   },
   render: function MyFunc({ ...args }) {
-    const [isOpen, setIsOpen] = useState(true);
+    const [, setIsOpen] = useState(false);
 
     return (
       <div>
         <button type="button" onClick={() => setIsOpen(true)}>
           open
         </button>
-        <Modal isOpen={isOpen} width={args.width}>
-          <Modal.Header onClickClose={() => setIsOpen(false)}>タイトル</Modal.Header>
+        <Modal isOpen setIsOpen={setIsOpen} width={args.width}>
+          <Modal.Header>タイトル</Modal.Header>
           <Modal.Body>
             <div className="flex h-[200px] w-full items-center justify-center">Content</div>
           </Modal.Body>
@@ -247,15 +247,15 @@ export const Danger: Story = {
     width: 420,
   },
   render: function MyFunc({ ...args }) {
-    const [isOpen, setIsOpen] = useState(true);
+    const [, setIsOpen] = useState(false);
 
     return (
       <div>
         <button type="button" onClick={() => setIsOpen(true)}>
           open
         </button>
-        <Modal isOpen={isOpen} width={args.width}>
-          <Modal.Header isNoBorder>
+        <Modal isOpen setIsOpen={setIsOpen} width={args.width}>
+          <Modal.Header isNoBorder isNoCloseButton>
             タイトル
           </Modal.Header>
           <Modal.Body>

--- a/packages/component-ui/src/modal/modal.stories.tsx
+++ b/packages/component-ui/src/modal/modal.stories.tsx
@@ -255,9 +255,7 @@ export const Danger: Story = {
           open
         </button>
         <Modal isOpen={isOpen} width={args.width}>
-          <Modal.Header isNoBorder>
-            タイトル
-          </Modal.Header>
+          <Modal.Header isNoBorder>タイトル</Modal.Header>
           <Modal.Body>
             <div className="flex h-16 w-full items-center justify-center">Content</div>
           </Modal.Body>

--- a/packages/component-ui/src/modal/modal.stories.tsx
+++ b/packages/component-ui/src/modal/modal.stories.tsx
@@ -255,7 +255,9 @@ export const Danger: Story = {
           open
         </button>
         <Modal isOpen={isOpen} width={args.width}>
-          <Modal.Header isNoBorder>タイトル</Modal.Header>
+          <Modal.Header isNoBorder>
+            タイトル
+          </Modal.Header>
           <Modal.Body>
             <div className="flex h-16 w-full items-center justify-center">Content</div>
           </Modal.Body>

--- a/packages/component-ui/src/modal/modal.stories.tsx
+++ b/packages/component-ui/src/modal/modal.stories.tsx
@@ -20,14 +20,14 @@ export const Base: Story = {
     width: 480,
   },
   render: function MyFunc({ ...args }) {
-    const [, setIsOpen] = useState(false);
+    const [isOpen, setIsOpen] = useState(true);
 
     return (
       <div>
         <button type="button" onClick={() => setIsOpen(true)}>
           open
         </button>
-        <Modal isOpen setIsOpen={setIsOpen} width={args.width}>
+        <Modal isOpen={isOpen} onClose={() => setIsOpen(false)} width={args.width}>
           <Modal.Header>タイトル</Modal.Header>
           <Modal.Body>
             <div className="flex h-[200px] w-full items-center justify-center">Content</div>
@@ -53,7 +53,7 @@ export const WithCheckbox: Story = {
     width: 480,
   },
   render: function MyFunc({ ...args }) {
-    const [, setIsOpen] = useState(false);
+    const [isOpen, setIsOpen] = useState(true);
     const [isChecked, setIsChecked] = useState(false);
 
     return (
@@ -61,7 +61,7 @@ export const WithCheckbox: Story = {
         <button type="button" onClick={() => setIsOpen(true)}>
           open
         </button>
-        <Modal isOpen setIsOpen={setIsOpen} width={args.width}>
+        <Modal isOpen={isOpen} onClose={() => setIsOpen(false)} width={args.width}>
           <Modal.Header>タイトル</Modal.Header>
           <Modal.Body>
             <div className="flex h-[200px] w-full items-center justify-center">Content</div>
@@ -97,14 +97,14 @@ export const WithSubButton: Story = {
     width: 480,
   },
   render: function MyFunc({ ...args }) {
-    const [, setIsOpen] = useState(false);
+    const [isOpen, setIsOpen] = useState(true);
 
     return (
       <div>
         <button type="button" onClick={() => setIsOpen(true)}>
           open
         </button>
-        <Modal isOpen setIsOpen={setIsOpen} width={args.width}>
+        <Modal isOpen={isOpen} onClose={() => setIsOpen(false)} width={args.width}>
           <Modal.Header>タイトル</Modal.Header>
           <Modal.Body>
             <div className="flex h-[200px] w-full items-center justify-center">Content</div>
@@ -137,14 +137,14 @@ export const FixedHeight: Story = {
     width: 480,
   },
   render: function MyFunc({ ...args }) {
-    const [, setIsOpen] = useState(false);
+    const [isOpen, setIsOpen] = useState(true);
 
     return (
       <div>
         <button type="button" onClick={() => setIsOpen(true)}>
           open
         </button>
-        <Modal isOpen setIsOpen={setIsOpen} width={args.width} height={500}>
+        <Modal isOpen={isOpen} onClose={() => setIsOpen(false)} width={args.width} height={500}>
           <Modal.Header>タイトル</Modal.Header>
           <Modal.Body>
             <div className="flex h-[800px] w-full items-center justify-center">Content</div>
@@ -170,7 +170,7 @@ export const WithTabs: Story = {
     width: 480,
   },
   render: function MyFunc({ ...args }) {
-    const [, setIsOpen] = useState(false);
+    const [isOpen, setIsOpen] = useState(true);
     const [selectedTab, setSelectedTab] = useState('tab1');
     const tabItems = [
       { id: 'tab1', label: 'タブラベル1' },
@@ -183,7 +183,7 @@ export const WithTabs: Story = {
         <button type="button" onClick={() => setIsOpen(true)}>
           open
         </button>
-        <Modal isOpen setIsOpen={setIsOpen} width={args.width}>
+        <Modal isOpen={isOpen} onClose={() => setIsOpen(false)} width={args.width}>
           <Modal.Header isNoBorder>タイトル</Modal.Header>
           <Modal.Body>
             <div className="mt-2 flex w-full flex-col">
@@ -224,14 +224,14 @@ export const WithoutButton: Story = {
     width: 480,
   },
   render: function MyFunc({ ...args }) {
-    const [, setIsOpen] = useState(false);
+    const [isOpen, setIsOpen] = useState(true);
 
     return (
       <div>
         <button type="button" onClick={() => setIsOpen(true)}>
           open
         </button>
-        <Modal isOpen setIsOpen={setIsOpen} width={args.width}>
+        <Modal isOpen={isOpen} onClose={() => setIsOpen(false)} width={args.width}>
           <Modal.Header>タイトル</Modal.Header>
           <Modal.Body>
             <div className="flex h-[200px] w-full items-center justify-center">Content</div>
@@ -247,14 +247,14 @@ export const Danger: Story = {
     width: 420,
   },
   render: function MyFunc({ ...args }) {
-    const [, setIsOpen] = useState(false);
+    const [isOpen, setIsOpen] = useState(true);
 
     return (
       <div>
         <button type="button" onClick={() => setIsOpen(true)}>
           open
         </button>
-        <Modal isOpen setIsOpen={setIsOpen} width={args.width}>
+        <Modal isOpen={isOpen} onClose={() => setIsOpen(false)} width={args.width}>
           <Modal.Header isNoBorder isNoCloseButton>
             タイトル
           </Modal.Header>

--- a/packages/component-ui/src/modal/modal.stories.tsx
+++ b/packages/component-ui/src/modal/modal.stories.tsx
@@ -20,15 +20,15 @@ export const Base: Story = {
     width: 480,
   },
   render: function MyFunc({ ...args }) {
-    const [, setIsOpen] = useState(false);
+    const [isOpen, setIsOpen] = useState(true);
 
     return (
       <div>
         <button type="button" onClick={() => setIsOpen(true)}>
           open
         </button>
-        <Modal isOpen setIsOpen={setIsOpen} width={args.width}>
-          <Modal.Header>タイトル</Modal.Header>
+        <Modal isOpen={isOpen} width={args.width}>
+          <Modal.Header onClickClose={() => setIsOpen(false)}>タイトル</Modal.Header>
           <Modal.Body>
             <div className="flex h-[200px] w-full items-center justify-center">Content</div>
           </Modal.Body>
@@ -53,7 +53,7 @@ export const WithCheckbox: Story = {
     width: 480,
   },
   render: function MyFunc({ ...args }) {
-    const [, setIsOpen] = useState(false);
+    const [isOpen, setIsOpen] = useState(true);
     const [isChecked, setIsChecked] = useState(false);
 
     return (
@@ -61,8 +61,8 @@ export const WithCheckbox: Story = {
         <button type="button" onClick={() => setIsOpen(true)}>
           open
         </button>
-        <Modal isOpen setIsOpen={setIsOpen} width={args.width}>
-          <Modal.Header>タイトル</Modal.Header>
+        <Modal isOpen={isOpen} width={args.width}>
+          <Modal.Header onClickClose={() => setIsOpen(false)}>タイトル</Modal.Header>
           <Modal.Body>
             <div className="flex h-[200px] w-full items-center justify-center">Content</div>
           </Modal.Body>
@@ -97,15 +97,15 @@ export const WithSubButton: Story = {
     width: 480,
   },
   render: function MyFunc({ ...args }) {
-    const [, setIsOpen] = useState(false);
+    const [isOpen, setIsOpen] = useState(true);
 
     return (
       <div>
         <button type="button" onClick={() => setIsOpen(true)}>
           open
         </button>
-        <Modal isOpen setIsOpen={setIsOpen} width={args.width}>
-          <Modal.Header>タイトル</Modal.Header>
+        <Modal isOpen={isOpen} width={args.width}>
+          <Modal.Header onClickClose={() => setIsOpen(false)}>タイトル</Modal.Header>
           <Modal.Body>
             <div className="flex h-[200px] w-full items-center justify-center">Content</div>
           </Modal.Body>
@@ -137,15 +137,15 @@ export const FixedHeight: Story = {
     width: 480,
   },
   render: function MyFunc({ ...args }) {
-    const [, setIsOpen] = useState(false);
+    const [isOpen, setIsOpen] = useState(true);
 
     return (
       <div>
         <button type="button" onClick={() => setIsOpen(true)}>
           open
         </button>
-        <Modal isOpen setIsOpen={setIsOpen} width={args.width} height={500}>
-          <Modal.Header>タイトル</Modal.Header>
+        <Modal isOpen={isOpen} width={args.width} height={500}>
+          <Modal.Header onClickClose={() => setIsOpen(false)}>タイトル</Modal.Header>
           <Modal.Body>
             <div className="flex h-[800px] w-full items-center justify-center">Content</div>
           </Modal.Body>
@@ -170,7 +170,7 @@ export const WithTabs: Story = {
     width: 480,
   },
   render: function MyFunc({ ...args }) {
-    const [, setIsOpen] = useState(false);
+    const [isOpen, setIsOpen] = useState(true);
     const [selectedTab, setSelectedTab] = useState('tab1');
     const tabItems = [
       { id: 'tab1', label: 'タブラベル1' },
@@ -183,8 +183,8 @@ export const WithTabs: Story = {
         <button type="button" onClick={() => setIsOpen(true)}>
           open
         </button>
-        <Modal isOpen setIsOpen={setIsOpen} width={args.width}>
-          <Modal.Header isNoBorder>タイトル</Modal.Header>
+        <Modal isOpen={isOpen} width={args.width}>
+          <Modal.Header onClickClose={() => setIsOpen(false)}>タイトル</Modal.Header>
           <Modal.Body>
             <div className="mt-2 flex w-full flex-col">
               <div className="w-full">
@@ -224,15 +224,15 @@ export const WithoutButton: Story = {
     width: 480,
   },
   render: function MyFunc({ ...args }) {
-    const [, setIsOpen] = useState(false);
+    const [isOpen, setIsOpen] = useState(true);
 
     return (
       <div>
         <button type="button" onClick={() => setIsOpen(true)}>
           open
         </button>
-        <Modal isOpen setIsOpen={setIsOpen} width={args.width}>
-          <Modal.Header>タイトル</Modal.Header>
+        <Modal isOpen={isOpen} width={args.width}>
+          <Modal.Header onClickClose={() => setIsOpen(false)}>タイトル</Modal.Header>
           <Modal.Body>
             <div className="flex h-[200px] w-full items-center justify-center">Content</div>
           </Modal.Body>
@@ -247,15 +247,15 @@ export const Danger: Story = {
     width: 420,
   },
   render: function MyFunc({ ...args }) {
-    const [, setIsOpen] = useState(false);
+    const [isOpen, setIsOpen] = useState(true);
 
     return (
       <div>
         <button type="button" onClick={() => setIsOpen(true)}>
           open
         </button>
-        <Modal isOpen setIsOpen={setIsOpen} width={args.width}>
-          <Modal.Header isNoBorder isNoCloseButton>
+        <Modal isOpen={isOpen} width={args.width}>
+          <Modal.Header isNoBorder>
             タイトル
           </Modal.Header>
           <Modal.Body>

--- a/packages/component-ui/src/modal/modal.tsx
+++ b/packages/component-ui/src/modal/modal.tsx
@@ -2,6 +2,7 @@ import { CSSProperties, MutableRefObject, PropsWithChildren } from 'react';
 import { createPortal } from 'react-dom';
 
 import { ModalBody } from './modal-body';
+import { ModalContext } from './modal-context';
 import { ModalFooter } from './modal-footer';
 import { ModalHeader } from './modal-header';
 
@@ -12,23 +13,26 @@ type Props = {
   width?: CSSProperties['width'];
   height?: CSSProperties['height'];
   isOpen: boolean;
+  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
   portalTargetRef?: MutableRefObject<HTMLElement | null>;
 };
 
-export function Modal({ children, width = 480, height, isOpen, portalTargetRef }: PropsWithChildren<Props>) {
+export function Modal({ children, width = 480, height, isOpen, setIsOpen, portalTargetRef }: PropsWithChildren<Props>) {
   const renderWidth = typeof width === 'number' ? Math.max(width, LIMIT_WIDTH) : width;
   const renderHeight = typeof height === 'number' ? Math.max(height, LIMIT_HEIGHT) : height;
 
   return createPortal(
     isOpen && (
-      <div className="fixed left-0 top-0 z-overlay flex h-full w-full items-center justify-center bg-background-backgroundOverlayBlack">
-        <div
-          className="flex shrink-0 flex-col rounded-lg bg-background-uiBackground01 shadow-modalShadow"
-          style={{ width: renderWidth, height: renderHeight }}
-        >
-          {children}
+      <ModalContext.Provider value={{ setIsOpen }}>
+        <div className="fixed left-0 top-0 z-overlay flex h-full w-full items-center justify-center bg-background-backgroundOverlayBlack">
+          <div
+            className="flex shrink-0 flex-col rounded-lg bg-background-uiBackground01 shadow-modalShadow"
+            style={{ width: renderWidth, height: renderHeight }}
+          >
+            {children}
+          </div>
         </div>
-      </div>
+      </ModalContext.Provider>
     ),
     !portalTargetRef || portalTargetRef?.current === null ? document.body : portalTargetRef.current,
   );

--- a/packages/component-ui/src/modal/modal.tsx
+++ b/packages/component-ui/src/modal/modal.tsx
@@ -2,7 +2,6 @@ import { CSSProperties, MutableRefObject, PropsWithChildren } from 'react';
 import { createPortal } from 'react-dom';
 
 import { ModalBody } from './modal-body';
-import { ModalContext } from './modal-context';
 import { ModalFooter } from './modal-footer';
 import { ModalHeader } from './modal-header';
 
@@ -13,26 +12,23 @@ type Props = {
   width?: CSSProperties['width'];
   height?: CSSProperties['height'];
   isOpen: boolean;
-  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
   portalTargetRef?: MutableRefObject<HTMLElement | null>;
 };
 
-export function Modal({ children, width = 480, height, isOpen, setIsOpen, portalTargetRef }: PropsWithChildren<Props>) {
+export function Modal({ children, width = 480, height, isOpen, portalTargetRef }: PropsWithChildren<Props>) {
   const renderWidth = typeof width === 'number' ? Math.max(width, LIMIT_WIDTH) : width;
   const renderHeight = typeof height === 'number' ? Math.max(height, LIMIT_HEIGHT) : height;
 
   return createPortal(
     isOpen && (
-      <ModalContext.Provider value={{ setIsOpen }}>
-        <div className="fixed left-0 top-0 z-overlay flex h-full w-full items-center justify-center bg-background-backgroundOverlayBlack">
-          <div
-            className="flex shrink-0 flex-col rounded-lg bg-background-uiBackground01 shadow-modalShadow"
-            style={{ width: renderWidth, height: renderHeight }}
-          >
-            {children}
-          </div>
+      <div className="fixed left-0 top-0 z-overlay flex h-full w-full items-center justify-center bg-background-backgroundOverlayBlack">
+        <div
+          className="flex shrink-0 flex-col rounded-lg bg-background-uiBackground01 shadow-modalShadow"
+          style={{ width: renderWidth, height: renderHeight }}
+        >
+          {children}
         </div>
-      </ModalContext.Provider>
+      </div>
     ),
     !portalTargetRef || portalTargetRef?.current === null ? document.body : portalTargetRef.current,
   );

--- a/packages/component-ui/src/modal/modal.tsx
+++ b/packages/component-ui/src/modal/modal.tsx
@@ -13,17 +13,17 @@ type Props = {
   width?: CSSProperties['width'];
   height?: CSSProperties['height'];
   isOpen: boolean;
-  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  onClose: () => void;
   portalTargetRef?: MutableRefObject<HTMLElement | null>;
 };
 
-export function Modal({ children, width = 480, height, isOpen, setIsOpen, portalTargetRef }: PropsWithChildren<Props>) {
+export function Modal({ children, width = 480, height, isOpen, onClose, portalTargetRef }: PropsWithChildren<Props>) {
   const renderWidth = typeof width === 'number' ? Math.max(width, LIMIT_WIDTH) : width;
   const renderHeight = typeof height === 'number' ? Math.max(height, LIMIT_HEIGHT) : height;
 
   return createPortal(
     isOpen && (
-      <ModalContext.Provider value={{ setIsOpen }}>
+      <ModalContext.Provider value={{ onClose }}>
         <div className="fixed left-0 top-0 z-overlay flex h-full w-full items-center justify-center bg-background-backgroundOverlayBlack">
           <div
             className="flex shrink-0 flex-col rounded-lg bg-background-uiBackground01 shadow-modalShadow"


### PR DESCRIPTION
modal のcloseボタンクリック時の制御方法の変更を行いました。

### 変更概要
- Modal の prop setIsOpen を廃止
- Modal に prop onClose を新設
