### PR TITLE
refactor: Tootip: 左右時のレイアウトの変更

### DIFF
--- a/packages/component-ui/src/tooltip/tail-icon.tsx
+++ b/packages/component-ui/src/tooltip/tail-icon.tsx
@@ -20,8 +20,8 @@ export const TailIcon = (props: Props) => {
     'right-4': props.horizontalAlign === 'right' && props.size !== 'small',
     'left-2': props.horizontalAlign === 'left' && props.size === 'small',
     'left-4': props.horizontalAlign === 'left' && props.size !== 'small',
-    'left-2/4 -translate-x-1': props.horizontalAlign === 'center' && props.size === 'small',
-    'left-2/4 -translate-x-2': props.horizontalAlign === 'center' && props.size !== 'small',
+    'left-1/2 -translate-x-1': props.horizontalAlign === 'center' && props.size === 'small',
+    'left-1/2 -translate-x-2': props.horizontalAlign === 'center' && props.size !== 'small',
   });
 
   if (props.size === 'small') {

--- a/packages/component-ui/src/tooltip/tooltip.stories.tsx
+++ b/packages/component-ui/src/tooltip/tooltip.stories.tsx
@@ -26,8 +26,8 @@ type Story = StoryObj<typeof Tooltip>;
 
 export const Base: Story = {
   render: ({ ...args }) => (
-    <div style={{ display: 'grid', rowGap: '50px', padding: '50px 100px' }}>
-      <div style={{ display: 'flex', alignItems: 'center', columnGap: '100px' }}>
+    <div className="grid gap-10 px-20 py-10">
+      <div className="flex items-center gap-20">
         <Tooltip {...args} content="内容説明テキストテキスト" verticalPosition="top" horizontalAlign="right">
           <div className="flex h-10 w-24 items-center justify-center rounded border border-gray-400">target</div>
         </Tooltip>
@@ -38,7 +38,7 @@ export const Base: Story = {
           <div className="flex h-10 w-24 items-center justify-center rounded border border-gray-400">target</div>
         </Tooltip>
       </div>
-      <div style={{ display: 'flex', alignItems: 'center', columnGap: '100px' }}>
+      <div className="flex items-center gap-20">
         <Tooltip {...args} content="内容説明テキストテキスト" verticalPosition="bottom" horizontalAlign="right">
           <div className="flex h-10 w-24 items-center justify-center rounded border border-gray-400">target</div>
         </Tooltip>
@@ -49,7 +49,7 @@ export const Base: Story = {
           <div className="flex h-10 w-24 items-center justify-center rounded border border-gray-400">target</div>
         </Tooltip>
       </div>
-      <div style={{ display: 'flex', alignItems: 'center', columnGap: '100px', marginTop: '100px' }}>
+      <div className="flex items-center gap-20">
         <Tooltip
           {...args}
           size="medium"
@@ -78,7 +78,7 @@ export const Base: Story = {
           <div className="flex h-10 w-24 items-center justify-center rounded border border-gray-400">target</div>
         </Tooltip>
       </div>
-      <div style={{ display: 'flex', alignItems: 'center', columnGap: '100px' }}>
+      <div className="flex items-center gap-20">
         <Tooltip
           {...args}
           size="medium"
@@ -105,6 +105,17 @@ export const Base: Story = {
           horizontalAlign="left"
         >
           <div className="flex h-10 w-24 items-center justify-center rounded border border-gray-400">target</div>
+        </Tooltip>
+      </div>
+      <div className="flex items-center gap-20">
+        <Tooltip {...args} size="medium" content="内容説明テキスト" verticalPosition="bottom" horizontalAlign="right">
+          <div className="flex h-10 w-[260px] items-center justify-center rounded border border-gray-400">target</div>
+        </Tooltip>
+        <Tooltip {...args} size="medium" content="内容説明テキスト" verticalPosition="bottom" horizontalAlign="center">
+          <div className="flex h-10 w-[260px] items-center justify-center rounded border border-gray-400">target</div>
+        </Tooltip>
+        <Tooltip {...args} size="medium" content="内容説明テキスト" verticalPosition="bottom" horizontalAlign="left">
+          <div className="flex h-10 w-[260px] items-center justify-center rounded border border-gray-400">target</div>
         </Tooltip>
       </div>
     </div>

--- a/packages/component-ui/src/tooltip/tooltip.tsx
+++ b/packages/component-ui/src/tooltip/tooltip.tsx
@@ -23,31 +23,29 @@ export function Tooltip({
   isDisabledHover = false,
 }: PropsWithChildren<Props>) {
   const [isVisible, setIsVisible] = useState(false);
-  const [targetDimensions, setTargetDimensions] = useState({
-    width: 0,
-    height: 0,
-  });
 
   const targetRef = useRef<HTMLDivElement>(null);
 
   const handleMouseOverWrapper = useCallback(() => {
-    if (targetRef.current === null || isDisabledHover) {
+    if (isDisabledHover) {
       return;
     }
-
-    const dimensions = targetRef.current.getBoundingClientRect();
-    const calculatedDimensions = {
-      width: dimensions.right - dimensions.left,
-      height: dimensions.bottom - dimensions.top,
-    };
-
-    setTargetDimensions(calculatedDimensions);
     setIsVisible(true);
   }, [isDisabledHover]);
 
   const handleMouseOutWrapper = useCallback(() => {
     setIsVisible(false);
   }, []);
+
+  const tooltipWrapClasses = clsx('absolute inset-x-0 z-tooltip m-auto flex', {
+    'top-0': verticalPosition !== 'bottom',
+    'bottom-0': verticalPosition === 'bottom',
+    'justify-start': horizontalAlign === 'left',
+    'justify-center': horizontalAlign === 'center',
+    'justify-end': horizontalAlign === 'right',
+    'w-[24px]': size === 'small',
+    'w-[46px]': size !== 'small',
+  });
 
   const tooltipBodyClasses = clsx(
     'absolute z-tooltip inline-block w-max rounded bg-background-uiBackgroundTooltip text-text-textOnColor',
@@ -56,9 +54,10 @@ export function Tooltip({
       'typography-body2regular': size === 'medium',
       'px-2 pb-1 pt-1.5': size === 'small',
       'px-4 py-3': size === 'medium',
-      'left-0': horizontalAlign === 'left',
-      'right-0': horizontalAlign === 'right',
-      'left-auto': horizontalAlign === 'center',
+      'bottom-2': verticalPosition !== 'bottom' && size === 'small',
+      'bottom-3': verticalPosition !== 'bottom' && size === 'medium',
+      'top-2': verticalPosition === 'bottom' && size === 'small',
+      'top-3': verticalPosition === 'bottom' && size === 'medium',
     },
   );
 
@@ -71,26 +70,16 @@ export function Tooltip({
     >
       {children}
       {isVisible && (
-        <div
-          className={tooltipBodyClasses}
-          style={{
-            maxWidth,
-            top:
-              verticalPosition === 'bottom'
-                ? size === 'small'
-                  ? `${targetDimensions.height + 8}px`
-                  : `${targetDimensions.height + 12}px`
-                : 'unset',
-            bottom:
-              verticalPosition === 'top'
-                ? size === 'small'
-                  ? `${targetDimensions.height + 8}px`
-                  : `${targetDimensions.height + 12}px`
-                : 'unset',
-          }}
-        >
-          {content}
-          <TailIcon size={size} verticalPosition={verticalPosition} horizontalAlign={horizontalAlign} />
+        <div className={tooltipWrapClasses}>
+          <div
+            className={tooltipBodyClasses}
+            style={{
+              maxWidth,
+            }}
+          >
+            {content}
+            <TailIcon size={size} verticalPosition={verticalPosition} horizontalAlign={horizontalAlign} />
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
Tooltip 横位置 左右レイアウトの変更を行いました。

### 行った修正
- horizontalAlign に left right  が指定された場合のレイアウトの変更を行いました。

### キャプチャ
<img width="745" alt="image" src="https://github.com/zenkigen/zenkigen-component/assets/6478212/2286dcde-be2d-4ed5-8f04-7f877e304653">

