### PR TITLE
wip: feat: Transitionの組み込み

### DIFF
--- a/packages/component-config/src/tailwind-config.ts
+++ b/packages/component-config/src/tailwind-config.ts
@@ -56,6 +56,10 @@ module.exports = {
         floatingShadow: tokens.shadow.floatingShadow,
         layoutShadow: tokens.shadow.layoutShadow,
       },
+      transitionDuration: {
+        'hover-over': '150ms',
+        'hover-out': '150ms',
+      },
       keyframes: {
         'circular-small-move': {
           '0%': {
@@ -125,13 +129,31 @@ module.exports = {
             transform: 'translate3d(-50%, 0, 0)',
           },
         },
+        'appear-in': {
+          from: {
+            opacity: 0,
+          },
+          to: {
+            opacity: 1,
+          },
+        },
+        'appear-out': {
+          from: {
+            opacity: 1,
+          },
+          to: {
+            opacity: 0,
+          },
+        },
       },
       animation: {
         'circular-small-move': 'circular-small-move 1.4s ease-in-out infinite',
         'circular-medium-move': 'circular-medium-move 1.4s ease-in-out infinite',
         'circular-large-move': 'circular-large-move 1.4s ease-in-out infinite',
-        'toast-in': 'toast-in 0.25s cubic-bezier(.11, .57, .14, 1)',
-        'toast-out': 'toast-out 0.25s cubic-bezier(0, .14, .75, 1)',
+        'toast-in': 'toast-in 1500ms cubic-bezier(0.075, 0.82, 0.165, 1)', // easeOutCirc
+        'toast-out': 'toast-out 1500ms cubic-bezier(0.6, 0.04, 0.98, 0.335)', // easeInCirc
+        'appear-in': 'appear-in 1500ms cubic-bezier(0.075, 0.82, 0.165, 1)', // easeOutCirc
+        'appear-out': 'appear-out 1500ms cubic-bezier(0.075, 0.82, 0.165, 1)', // easeOutCirc
       },
       zIndex: {
         hide: -1,

--- a/packages/component-ui/src/button/button.tsx
+++ b/packages/component-ui/src/button/button.tsx
@@ -44,7 +44,7 @@ export const Button = <T extends ElementAs = 'button'>({
   ...props
 }: Props<T>) => {
   const baseClasses = clsx(
-    'flex shrink-0 items-center justify-center gap-1',
+    'flex shrink-0 items-center justify-center gap-1 transition-colors duration-hover-out hover:transition-colors hover:duration-hover-over [&:hover>*]:transition-colors [&:hover>*]:duration-hover-over [&>*]:transition-colors [&>*]:duration-hover-out',
     buttonColors[variant].hover,
     buttonColors[variant].active,
     buttonColors[variant].disabled,

--- a/packages/component-ui/src/dropdown/dropdown-context.ts
+++ b/packages/component-ui/src/dropdown/dropdown-context.ts
@@ -10,6 +10,8 @@ type UseDropdownReturnType = {
     width: number;
     height: number;
   };
+  isRemoving?: boolean;
+  setIsRemoving: React.Dispatch<React.SetStateAction<boolean>>;
   variant: 'text' | 'outline';
 };
 
@@ -18,5 +20,7 @@ export const DropdownContext = createContext<UseDropdownReturnType>({
   setIsVisible: () => false,
   isDisabled: false,
   targetDimensions: { width: 0, height: 0 },
+  isRemoving: false,
+  setIsRemoving: () => false,
   variant: 'outline',
 });

--- a/packages/component-ui/src/dropdown/dropdown-item.tsx
+++ b/packages/component-ui/src/dropdown/dropdown-item.tsx
@@ -11,9 +11,9 @@ type Props = {
 };
 
 export function DropdownItem({ children, color = 'gray', onClick }: PropsWithChildren<Props>) {
-  const { setIsVisible } = useContext(DropdownContext);
+  const { setIsRemoving } = useContext(DropdownContext);
   const handleClickItem = (event: MouseEvent<HTMLButtonElement>) => {
-    setIsVisible(false);
+    setIsRemoving(true);
     onClick && onClick(event);
   };
   const itemClasses = clsx(

--- a/packages/component-ui/src/dropdown/dropdown-menu.tsx
+++ b/packages/component-ui/src/dropdown/dropdown-menu.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import type { CSSProperties, PropsWithChildren } from 'react';
+import type { AnimationEvent, CSSProperties, PropsWithChildren } from 'react';
 import { useContext } from 'react';
 
 import { DropdownContext } from './dropdown-context';
@@ -19,7 +19,24 @@ export function DropdownMenu({
   verticalPosition = 'bottom',
   horizontalAlign = 'left',
 }: PropsWithChildren<Props>) {
-  const { isVisible, isDisabled, targetDimensions, variant, portalTargetRef } = useContext(DropdownContext);
+  const {
+    isVisible,
+    setIsVisible,
+    isDisabled,
+    targetDimensions,
+    variant,
+    portalTargetRef,
+    isRemoving = false,
+    setIsRemoving,
+  } = useContext(DropdownContext);
+
+  const handleAnimationEnd = (e: AnimationEvent<HTMLElement>) => {
+    if (window.getComputedStyle(e.currentTarget).opacity === '0') {
+      setIsRemoving(false);
+      setIsVisible(false);
+    }
+  };
+
   const wrapperClasses = clsx('z-dropdown w-max overflow-y-auto rounded bg-uiBackground01 shadow-floatingShadow', {
     absolute: !portalTargetRef,
     'border-solid border border-uiBorder01': variant === 'outline',
@@ -27,6 +44,8 @@ export function DropdownMenu({
     'left-0': horizontalAlign === 'left',
     'right-0': horizontalAlign === 'right',
     'left-auto': horizontalAlign === 'center',
+    [`animate-appear-in`]: !isRemoving,
+    ['animate-appear-out opacity-0']: isRemoving,
   });
 
   return (
@@ -39,6 +58,7 @@ export function DropdownMenu({
           bottom: !portalTargetRef && verticalPosition === 'top' ? `${targetDimensions.height + 4}px` : 'unset',
           maxHeight,
         }}
+        onAnimationEnd={handleAnimationEnd}
       >
         {children}
       </ul>

--- a/packages/component-ui/src/dropdown/dropdown.tsx
+++ b/packages/component-ui/src/dropdown/dropdown.tsx
@@ -40,39 +40,40 @@ export function Dropdown({
   portalTargetRef,
 }: PropsWithChildren<Props>) {
   const [isVisible, setIsVisible] = useState(false);
+  const [isRemoving, setIsRemoving] = useState(false);
   const [targetDimensions, setTargetDimensions] = useState({
     width: 0,
     height: 0,
   });
 
   const targetRef = useRef<HTMLDivElement>(null);
-  useOutsideClick(targetRef, () => setIsVisible(false));
+  useOutsideClick(targetRef, () => setIsRemoving(true));
 
   const handleToggle = useCallback(() => {
     if (targetRef.current === null) {
       return;
     }
 
-    if (isVisible) {
-      setIsVisible(false);
+    if (!isRemoving) {
+      setIsRemoving(true);
     } else {
       const dimensions = targetRef.current.getBoundingClientRect();
       const calculatedDimensions = {
         width: dimensions.right - dimensions.left,
         height: dimensions.bottom - dimensions.top,
       };
-
       setTargetDimensions(calculatedDimensions);
       setIsVisible(true);
+      setIsRemoving(false);
     }
-  }, [isVisible]);
+  }, [isRemoving]);
 
   const wrapperClasses = clsx('relative flex shrink-0 items-center gap-1 rounded', {
     'cursor-not-allowed': isDisabled,
   });
 
   const childrenButtonClasses = clsx(
-    'flex items-center justify-center rounded p-1 hover:bg-hover02 active:bg-active02',
+    'flex items-center justify-center rounded p-1 transition-colors duration-hover-out hover:bg-hover02 hover:transition-colors hover:duration-hover-over active:bg-active02',
     focusVisible.normal,
     {
       'pointer-events-none': isDisabled,
@@ -81,7 +82,7 @@ export function Dropdown({
   );
 
   const buttonClasses = clsx(
-    'flex items-center rounded',
+    'flex items-center rounded transition-colors duration-hover-out hover:transition-colors hover:duration-hover-over',
     buttonColors[variant].base,
     buttonColors[variant].hover,
     buttonColors[variant].active,
@@ -105,7 +106,16 @@ export function Dropdown({
 
   return (
     <DropdownContext.Provider
-      value={{ isVisible, setIsVisible, isDisabled, targetDimensions, variant, portalTargetRef }}
+      value={{
+        isVisible,
+        setIsVisible,
+        isDisabled,
+        targetDimensions,
+        variant,
+        portalTargetRef,
+        isRemoving,
+        setIsRemoving,
+      }}
     >
       <div ref={targetRef} className={wrapperClasses}>
         {target ? (

--- a/packages/component-ui/src/icon-button/icon-button.tsx
+++ b/packages/component-ui/src/icon-button/icon-button.tsx
@@ -34,7 +34,7 @@ export function IconButton({
   ...props
 }: Props) {
   const baseClasses = clsx(
-    'typography-label1regular flex items-center justify-center gap-1 rounded',
+    'typography-label1regular flex items-center justify-center gap-1 rounded transition-colors duration-hover-out hover:transition-colors hover:duration-hover-over [&:hover>*]:transition-colors [&:hover>*]:duration-hover-over [&>*]:transition-colors [&>*]:duration-hover-out',
     buttonColors[variant].base,
     buttonColors[variant].hover,
     buttonColors[variant].active,

--- a/packages/component-ui/src/modal/modal.tsx
+++ b/packages/component-ui/src/modal/modal.tsx
@@ -1,4 +1,5 @@
-import type { CSSProperties, MutableRefObject, PropsWithChildren } from 'react';
+import clsx from 'clsx';
+import type { AnimationEvent, CSSProperties, MutableRefObject, PropsWithChildren } from 'react';
 import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 
@@ -20,9 +21,29 @@ type Props = {
 
 export function Modal({ children, width = 480, height, isOpen, onClose, portalTargetRef }: PropsWithChildren<Props>) {
   const [isMounted, setIsMounted] = useState(false);
+  const [isRemoving, setIsRemoving] = useState(false);
 
   const renderWidth = typeof width === 'number' ? Math.max(width, LIMIT_WIDTH) : width;
   const renderHeight = typeof height === 'number' ? Math.max(height, LIMIT_HEIGHT) : height;
+
+  const handleAnimationEnd = (e: AnimationEvent<HTMLDivElement>) => {
+    if (window.getComputedStyle(e.currentTarget).opacity === '0') {
+      onClose && onClose();
+      setIsRemoving(false);
+    }
+  };
+
+  const handleClose = () => {
+    setIsRemoving(true);
+  };
+
+  const wrapperClasses = clsx(
+    'fixed left-0 top-0 z-overlay flex size-full items-center justify-center bg-backgroundOverlayBlack py-4',
+    {
+      ['animate-appear-in']: !isRemoving,
+      ['animate-appear-out opacity-0']: isRemoving,
+    },
+  );
 
   useEffect(() => {
     setIsMounted(true);
@@ -30,8 +51,8 @@ export function Modal({ children, width = 480, height, isOpen, onClose, portalTa
 
   return isMounted && isOpen
     ? createPortal(
-        <ModalContext.Provider value={{ onClose }}>
-          <div className="fixed left-0 top-0 z-overlay flex size-full items-center justify-center bg-backgroundOverlayBlack py-4">
+        <ModalContext.Provider value={{ onClose: handleClose }}>
+          <div className={wrapperClasses} onAnimationEnd={handleAnimationEnd}>
             <div
               className="grid max-h-full min-h-[120px] grid-rows-[max-content_1fr_max-content] flex-col rounded-lg bg-uiBackground01 shadow-modalShadow"
               style={{ width: renderWidth, height: renderHeight }}

--- a/packages/component-ui/src/select-sort/select-item.tsx
+++ b/packages/component-ui/src/select-sort/select-item.tsx
@@ -11,7 +11,7 @@ type Props = {
 
 export function SelectItem({ children, isSortKey, onClickItem }: PropsWithChildren<Props>) {
   const itemClasses = clsx(
-    'typography-label2regular flex h-8 w-full items-center px-3 hover:bg-hover02 active:bg-active02',
+    'typography-label2regular flex h-8 w-full items-center px-3 transition-colors duration-hover-out hover:bg-hover02 hover:transition-colors hover:duration-hover-over active:bg-active02',
     focusVisible.inset,
     {
       'bg-selectedUi fill-interactive01 text-interactive01': isSortKey,

--- a/packages/component-ui/src/select-sort/select-list.tsx
+++ b/packages/component-ui/src/select-sort/select-list.tsx
@@ -1,7 +1,10 @@
 import { focusVisible } from '@zenkigen-inc/component-theme';
 import clsx from 'clsx';
+import type { AnimationEvent } from 'react';
+import { useContext } from 'react';
 
 import { SelectItem } from './select-item';
+import { SelectSortContext } from './select-sort-context';
 import type { SortOrder } from './type';
 
 type Props = {
@@ -13,6 +16,15 @@ type Props = {
 };
 
 export function SelectList({ size, variant, sortOrder, onClickItem, onClickDeselect }: Props) {
+  const { setIsOptionListOpen, isRemoving = false, setIsRemoving } = useContext(SelectSortContext);
+
+  const handleAnimationEnd = (e: AnimationEvent<HTMLElement>) => {
+    if (window.getComputedStyle(e.currentTarget).opacity === '0') {
+      setIsRemoving(false);
+      setIsOptionListOpen(false);
+    }
+  };
+
   const listClasses = clsx(
     'absolute z-dropdown w-max overflow-y-auto rounded bg-uiBackground01 py-2 shadow-floatingShadow',
     {
@@ -20,16 +32,18 @@ export function SelectList({ size, variant, sortOrder, onClickItem, onClickDesel
       'top-9': size === 'medium',
       'top-11': size === 'large',
       'border-solid border border-uiBorder01': variant === 'outline',
+      [`animate-appear-in`]: !isRemoving,
+      ['animate-appear-out opacity-0']: isRemoving,
     },
   );
 
   const deselectButtonClasses = clsx(
-    'typography-label2regular flex h-8 w-full items-center px-3 text-interactive02 hover:bg-hover02 active:bg-active02',
+    'typography-label2regular flex h-8 w-full items-center px-3 text-interactive02 transition-colors duration-hover-out hover:bg-hover02 hover:transition-colors hover:duration-hover-over active:bg-active02',
     focusVisible.inset,
   );
 
   return (
-    <ul className={listClasses}>
+    <ul className={listClasses} onAnimationEnd={handleAnimationEnd}>
       <SelectItem isSortKey={sortOrder === 'ascend'} onClickItem={() => onClickItem('ascend')}>
         昇順で並び替え
       </SelectItem>

--- a/packages/component-ui/src/select-sort/select-sort-context.ts
+++ b/packages/component-ui/src/select-sort/select-sort-context.ts
@@ -1,0 +1,13 @@
+import { createContext } from 'react';
+
+type UseSelectSortReturnType = {
+  setIsOptionListOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  isRemoving?: boolean;
+  setIsRemoving: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
+export const SelectSortContext = createContext<UseSelectSortReturnType>({
+  setIsOptionListOpen: () => false,
+  isRemoving: false,
+  setIsRemoving: () => false,
+});

--- a/packages/component-ui/src/select-sort/select-sort.tsx
+++ b/packages/component-ui/src/select-sort/select-sort.tsx
@@ -6,6 +6,7 @@ import { useCallback, useRef, useState } from 'react';
 import { useOutsideClick } from '../hooks/use-outside-click';
 import { Icon } from '../icon';
 import { SelectList } from './select-list';
+import { SelectSortContext } from './select-sort-context';
 import type { SortOrder } from './type';
 
 type Props = {
@@ -32,14 +33,23 @@ export function SelectSort({
   onClickDeselect,
 }: Props) {
   const [isOptionListOpen, setIsOptionListOpen] = useState(false);
+  const [isRemoving, setIsRemoving] = useState(false);
   const targetRef = useRef<HTMLDivElement>(null);
-  useOutsideClick(targetRef, () => setIsOptionListOpen(false));
+  useOutsideClick(targetRef, () => setIsRemoving(true));
 
-  const handleClickToggle = () => setIsOptionListOpen((prev) => !prev);
+  const handleClickToggle = () => {
+    if (isRemoving || !isOptionListOpen) {
+      setIsRemoving(false);
+      setIsOptionListOpen(true);
+    } else {
+      setIsRemoving(true);
+    }
+  };
+
   const handleClickItem = useCallback(
     (value: SortOrder) => {
       onChange?.(value);
-      setIsOptionListOpen(false);
+      setIsRemoving(true);
     },
     [onChange],
   );
@@ -52,7 +62,7 @@ export function SelectSort({
   });
 
   const buttonClasses = clsx(
-    'flex size-full items-center rounded',
+    'flex size-full items-center rounded transition-colors duration-hover-out hover:transition-colors hover:duration-hover-over',
     buttonColors[variant].hover,
     buttonColors[variant].active,
     buttonColors[variant].disabled,
@@ -75,32 +85,34 @@ export function SelectSort({
   });
 
   return (
-    <div className={wrapperClasses} style={{ width }} ref={targetRef}>
-      <button className={buttonClasses} type="button" onClick={handleClickToggle} disabled={isDisabled}>
-        <div className={labelClasses}>{label}</div>
-        <div className="ml-auto flex items-center">
-          {isSortKey ? (
-            <Icon
-              name={sortOrder === 'ascend' ? 'arrow-up' : 'arrow-down'}
-              size={size === 'large' ? 'medium' : 'small'}
-            />
-          ) : (
-            <Icon
-              name={isOptionListOpen ? 'angle-small-up' : 'angle-small-down'}
-              size={size === 'large' ? 'medium' : 'small'}
-            />
-          )}
-        </div>
-      </button>
-      {isOptionListOpen && !isDisabled && (
-        <SelectList
-          size={size}
-          variant={variant}
-          sortOrder={sortOrder}
-          onClickItem={handleClickItem}
-          onClickDeselect={onClickDeselect}
-        />
-      )}
-    </div>
+    <SelectSortContext.Provider value={{ setIsOptionListOpen, isRemoving, setIsRemoving }}>
+      <div className={wrapperClasses} style={{ width }} ref={targetRef}>
+        <button className={buttonClasses} type="button" onClick={handleClickToggle} disabled={isDisabled}>
+          <div className={labelClasses}>{label}</div>
+          <div className="ml-auto flex items-center">
+            {isSortKey ? (
+              <Icon
+                name={sortOrder === 'ascend' ? 'arrow-up' : 'arrow-down'}
+                size={size === 'large' ? 'medium' : 'small'}
+              />
+            ) : (
+              <Icon
+                name={isOptionListOpen ? 'angle-small-up' : 'angle-small-down'}
+                size={size === 'large' ? 'medium' : 'small'}
+              />
+            )}
+          </div>
+        </button>
+        {isOptionListOpen && !isDisabled && (
+          <SelectList
+            size={size}
+            variant={variant}
+            sortOrder={sortOrder}
+            onClickItem={handleClickItem}
+            onClickDeselect={onClickDeselect}
+          />
+        )}
+      </div>
+    </SelectSortContext.Provider>
   );
 }

--- a/packages/component-ui/src/select/select-context.ts
+++ b/packages/component-ui/src/select/select-context.ts
@@ -8,11 +8,15 @@ type UseSelectReturnType = {
   selectedOption?: SelectOption | null;
   setIsOptionListOpen: React.Dispatch<React.SetStateAction<boolean>>;
   onChange?: (option: SelectOption | null) => void;
+  isRemoving?: boolean;
+  setIsRemoving: React.Dispatch<React.SetStateAction<boolean>>;
   variant?: 'text' | 'outline';
 };
 
 export const SelectContext = createContext<UseSelectReturnType>({
   size: 'medium',
   setIsOptionListOpen: () => false,
+  isRemoving: false,
+  setIsRemoving: () => false,
   variant: 'outline',
 });

--- a/packages/component-ui/src/select/select-item.tsx
+++ b/packages/component-ui/src/select/select-item.tsx
@@ -11,11 +11,11 @@ type Props = {
 };
 
 export function SelectItem({ option }: Props) {
-  const { setIsOptionListOpen, selectedOption, onChange } = useContext(SelectContext);
+  const { selectedOption, onChange, setIsRemoving } = useContext(SelectContext);
 
   const handleClickItem = (option: SelectOption) => {
     onChange?.(option);
-    setIsOptionListOpen(false);
+    setIsRemoving(true);
   };
 
   const itemClasses = clsx(

--- a/packages/component-ui/src/select/select-list.tsx
+++ b/packages/component-ui/src/select/select-list.tsx
@@ -1,6 +1,6 @@
 import { focusVisible } from '@zenkigen-inc/component-theme';
 import clsx from 'clsx';
-import type { CSSProperties, PropsWithChildren } from 'react';
+import type { AnimationEvent, CSSProperties, PropsWithChildren } from 'react';
 import { useContext, useLayoutEffect, useRef } from 'react';
 
 import { SelectContext } from './select-context';
@@ -11,11 +11,27 @@ type Props = {
 
 export function SelectList({ children, maxHeight }: PropsWithChildren<Props>) {
   const ref = useRef<HTMLUListElement>(null);
-  const { size, selectedOption, setIsOptionListOpen, variant, placeholder, onChange } = useContext(SelectContext);
+  const {
+    size,
+    selectedOption,
+    setIsOptionListOpen,
+    variant,
+    placeholder,
+    onChange,
+    isRemoving = false,
+    setIsRemoving,
+  } = useContext(SelectContext);
+
+  const handleAnimationEnd = (e: AnimationEvent<HTMLElement>) => {
+    if (window.getComputedStyle(e.currentTarget).opacity === '0') {
+      setIsRemoving(false);
+      setIsOptionListOpen(false);
+    }
+  };
 
   const handleClickDeselect = () => {
     onChange?.(null);
-    setIsOptionListOpen(false);
+    setIsRemoving(true);
   };
 
   useLayoutEffect(() => {
@@ -39,6 +55,8 @@ export function SelectList({ children, maxHeight }: PropsWithChildren<Props>) {
       'top-9': size === 'medium',
       'top-11': size === 'large',
       'border-solid border border-uiBorder01': variant === 'outline',
+      [`animate-appear-in`]: !isRemoving,
+      ['animate-appear-out opacity-0']: isRemoving,
     },
   );
 
@@ -48,7 +66,7 @@ export function SelectList({ children, maxHeight }: PropsWithChildren<Props>) {
   );
 
   return (
-    <ul className={listClasses} style={{ maxHeight }} ref={ref}>
+    <ul className={listClasses} style={{ maxHeight }} ref={ref} onAnimationEnd={handleAnimationEnd}>
       {children}
       {placeholder != null && selectedOption !== null && (
         <li>

--- a/packages/component-ui/src/select/select.tsx
+++ b/packages/component-ui/src/select/select.tsx
@@ -36,17 +36,28 @@ export function Select({
   optionListMaxHeight,
 }: PropsWithChildren<Props>) {
   const [isOptionListOpen, setIsOptionListOpen] = useState(false);
+  const [isRemoving, setIsRemoving] = useState(false);
   const targetRef = useRef<HTMLDivElement>(null);
-  useOutsideClick(targetRef, () => setIsOptionListOpen(false));
+  useOutsideClick(targetRef, () => setIsRemoving(true));
 
-  const handleClickToggle = () => setIsOptionListOpen((prev) => !prev);
+  const handleClickToggle = () => {
+    if (isRemoving || !isOptionListOpen) {
+      setIsRemoving(false);
+      setIsOptionListOpen(true);
+    } else {
+      setIsRemoving(true);
+    }
+  };
 
-  const wrapperClasses = clsx('relative flex shrink-0 items-center gap-1 rounded', {
-    'h-6': size === 'x-small' || size === 'small',
-    'h-8': size === 'medium',
-    'h-10': size === 'large',
-    'cursor-not-allowed': isDisabled,
-  });
+  const wrapperClasses = clsx(
+    'relative flex shrink-0 items-center gap-1 rounded transition-colors duration-hover-out hover:transition-colors hover:duration-hover-over [&:hover>*]:transition-colors [&:hover>*]:duration-hover-over [&>*]:transition-colors [&>*]:duration-hover-out',
+    {
+      'h-6': size === 'x-small' || size === 'small',
+      'h-8': size === 'medium',
+      'h-10': size === 'large',
+      'cursor-not-allowed': isDisabled,
+    },
+  );
 
   const buttonClasses = clsx(
     'flex size-full items-center rounded',
@@ -79,6 +90,8 @@ export function Select({
         setIsOptionListOpen,
         selectedOption,
         onChange,
+        isRemoving,
+        setIsRemoving,
       }}
     >
       <div className={wrapperClasses} style={{ width }} ref={targetRef}>

--- a/packages/component-ui/src/tab/tab-item.tsx
+++ b/packages/component-ui/src/tab/tab-item.tsx
@@ -11,7 +11,7 @@ type Props = {
 
 export const TabItem = ({ isSelected = false, ...props }: Props) => {
   const classes = clsx(
-    'relative z-0 flex py-2 leading-[24px] before:absolute before:inset-x-0 before:bottom-0 before:h-px hover:text-text01 disabled:pointer-events-none disabled:text-disabled01',
+    'relative z-0 flex py-2 leading-[24px] transition-colors duration-hover-out before:absolute before:inset-x-0 before:bottom-0 before:h-px before:transition-colors hover:text-text01 hover:transition-colors hover:duration-hover-over disabled:pointer-events-none disabled:text-disabled01 ',
     {
       'typography-label2regular': !isSelected,
       'text-interactive02 hover:before:bg-uiBorder02Dark': !isSelected,

--- a/packages/component-ui/src/text-area/text-area.stories.tsx
+++ b/packages/component-ui/src/text-area/text-area.stories.tsx
@@ -4,6 +4,7 @@ import clsx from 'clsx';
 import type { ChangeEvent, ReactNode } from 'react';
 import { useState } from 'react';
 
+import { Button } from '../button';
 import { TextArea } from '.';
 
 const meta: Meta<typeof TextArea> = {
@@ -205,6 +206,49 @@ export const Base: Story = {
               }}
             />
             <ErrorText>入力済み ＋ disabled</ErrorText>
+          </div>
+        </div>
+      </div>
+    );
+  },
+};
+
+export const Test: Story = {
+  args: {},
+  render: function MyFunc({ ...args }) {
+    const [value, setValue] = useState<string>(args.value);
+    const [hasError, setHasError] = useState<boolean>(false);
+
+    const handleEnter = () => {
+      if (value === 'abcde') {
+        setHasError(false);
+      } else {
+        setHasError(true);
+      }
+    };
+
+    return (
+      <div className="flex gap-10">
+        <div style={{ width: 400 }} className="flex flex-col gap-12">
+          <div>
+            <TextArea
+              value={value}
+              placeholder="入力してください"
+              size="large"
+              height={120}
+              isResizable
+              onFocus={() => setHasError(false)}
+              onChange={(e: ChangeEvent<HTMLTextAreaElement>) => {
+                action('onChange')(e);
+                setValue(e.target.value);
+              }}
+              isError={hasError}
+            />
+            <ErrorText>abcdeと入力されるまでエラーになります。</ErrorText>
+          </div>
+          <div className="flex flex-col gap-2">
+            <Button onClick={handleEnter}>確認</Button>
+            <Button onClick={() => setHasError(false)}>エラーをクリア</Button>
           </div>
         </div>
       </div>

--- a/packages/component-ui/src/text-area/text-area.tsx
+++ b/packages/component-ui/src/text-area/text-area.tsx
@@ -13,7 +13,7 @@ type Props = TextareaHTMLAttributes<HTMLTextAreaElement> & {
 export const TextArea = forwardRef<HTMLTextAreaElement, Props>(
   ({ size = 'medium', isResizable = false, isError = false, disabled = false, ...props }: Props, ref) => {
     const classes = clsx(
-      'w-full rounded border outline-0 placeholder:text-textPlaceholder disabled:text-textPlaceholder',
+      'w-full rounded border outline-0 transition-colors duration-hover-out placeholder:text-textPlaceholder hover:transition-colors hover:duration-hover-over disabled:text-textPlaceholder',
       {
         'border-supportError': isError && !disabled,
         'hover:border-hoverInput': !disabled && !isError,

--- a/packages/component-ui/src/text-input/text-input.stories.tsx
+++ b/packages/component-ui/src/text-input/text-input.stories.tsx
@@ -4,6 +4,7 @@ import clsx from 'clsx';
 import type { ChangeEvent, ReactNode } from 'react';
 import { useState } from 'react';
 
+import { Button } from '../button';
 import { TextInput } from '.';
 
 const meta: Meta<typeof TextInput> = {
@@ -251,6 +252,53 @@ export const Base: Story = {
               }}
               type="password"
             />
+          </div>
+        </div>
+      </div>
+    );
+  },
+};
+
+export const Test: Story = {
+  args: {
+    value: '',
+  },
+  render: function MyFunc({ ...args }) {
+    const [value, setValue] = useState<string>(args.value);
+    const [hasError, setHasError] = useState<boolean>(false);
+
+    const handleEnter = () => {
+      if (value === 'abcde') {
+        setHasError(false);
+      } else {
+        setHasError(true);
+      }
+    };
+
+    return (
+      <div className="flex gap-10">
+        <div style={{ width: 300 }} className="flex flex-col gap-10">
+          <div>
+            <TextInput
+              value={value}
+              placeholder="入力してください"
+              size="large"
+              onFocus={() => setHasError(false)}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                action('onChange')(e);
+                setValue(e.target.value);
+              }}
+              onClickClearButton={() => {
+                setHasError(false);
+                setValue('');
+              }}
+              isError={hasError}
+            />
+            <ErrorText>abcdeと入力されるまでエラーになります。</ErrorText>
+          </div>
+          <div className="flex flex-col gap-2">
+            <Button onClick={handleEnter}>確認</Button>
+            <Button onClick={() => setHasError(false)}>エラーをクリア</Button>
           </div>
         </div>
       </div>

--- a/packages/component-ui/src/text-input/text-input.tsx
+++ b/packages/component-ui/src/text-input/text-input.tsx
@@ -13,17 +13,20 @@ type Props = Omit<InputHTMLAttributes<HTMLInputElement>, 'size'> & {
 
 export const TextInput = forwardRef<HTMLInputElement, Props>(
   ({ size = 'medium', isError = false, disabled = false, onClickClearButton, ...props }: Props, ref) => {
-    const inputWrapClasses = clsx('relative flex items-center gap-2 overflow-hidden rounded border', {
-      'border-uiBorder01': !isError,
-      'border-supportError': isError && !disabled,
-      'hover:border-hoverInput': !disabled && !isError,
-      'hover:focus-within:border-activeInput': !isError,
-      'focus-within:border-activeInput': !isError,
-      'bg-disabled02 border-disabled01': disabled,
-    });
+    const inputWrapClasses = clsx(
+      'relative flex items-center gap-2 overflow-hidden rounded border transition-colors duration-hover-out hover:transition-colors hover:duration-hover-over',
+      {
+        'border-uiBorder01': !isError,
+        'border-supportError': isError && !disabled,
+        'hover:border-hoverInput': !disabled && !isError,
+        'hover:focus-within:border-activeInput': !isError,
+        'focus-within:border-activeInput': !isError,
+        'bg-disabled02 border-disabled01': disabled,
+      },
+    );
 
     const inputClasses = clsx(
-      'flex-1 pl-2 pr-3 outline-0 placeholder:text-textPlaceholder disabled:text-textPlaceholder',
+      'flex-1 pl-2 pr-3 outline-0 transition-colors duration-hover-out placeholder:text-textPlaceholder disabled:text-textPlaceholder',
       {
         ['typography-label2regular pt-1.5 pb-2']: size === 'medium',
         ['typography-label1regular py-2.5']: size === 'large',

--- a/packages/component-ui/src/tooltip/tooltip-content.tsx
+++ b/packages/component-ui/src/tooltip/tooltip-content.tsx
@@ -1,7 +1,8 @@
 import clsx from 'clsx';
-import type { CSSProperties } from 'react';
+import { type AnimationEvent, type CSSProperties, useContext } from 'react';
 
 import { TailIcon } from './tail-icon';
+import { TooltipContext } from './tooltip-context';
 import type { TooltipHorizontalAlign, TooltipPosition, TooltipSize, TooltipVerticalPosition } from './type';
 
 export const TooltipContent = ({
@@ -21,6 +22,15 @@ export const TooltipContent = ({
   tooltipPosition: TooltipPosition;
   isPortal?: boolean;
 }) => {
+  const { setIsVisible, isRemoving = false, setIsRemoving } = useContext(TooltipContext);
+
+  const handleAnimationEnd = (e: AnimationEvent<HTMLElement>) => {
+    if (window.getComputedStyle(e.currentTarget).opacity === '0') {
+      setIsRemoving(false);
+      setIsVisible(false);
+    }
+  };
+
   const tooltipWrapperClasses = clsx('absolute z-tooltip m-auto flex', {
     'top-0': !isPortal && verticalPosition === 'top',
     'bottom-0': !isPortal && verticalPosition === 'bottom',
@@ -29,6 +39,8 @@ export const TooltipContent = ({
     'justify-end': horizontalAlign === 'right',
     'w-[24px]': size === 'small',
     'w-[46px]': size !== 'small',
+    [`animate-appear-in`]: !isRemoving,
+    ['animate-appear-out opacity-0']: isRemoving,
   });
 
   const tooltipBodyClasses = clsx(
@@ -53,7 +65,7 @@ export const TooltipContent = ({
     : {};
 
   return (
-    <div className={tooltipWrapperClasses} style={tooltipWrapperStyle}>
+    <div className={tooltipWrapperClasses} style={tooltipWrapperStyle} onAnimationEnd={handleAnimationEnd}>
       <div
         className={tooltipBodyClasses}
         style={{

--- a/packages/component-ui/src/tooltip/tooltip-context.ts
+++ b/packages/component-ui/src/tooltip/tooltip-context.ts
@@ -1,0 +1,13 @@
+import { createContext } from 'react';
+
+type UseTooltipReturnType = {
+  setIsVisible: React.Dispatch<React.SetStateAction<boolean>>;
+  isRemoving?: boolean;
+  setIsRemoving: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
+export const TooltipContext = createContext<UseTooltipReturnType>({
+  setIsVisible: () => false,
+  isRemoving: false,
+  setIsRemoving: () => false,
+});


### PR DESCRIPTION
> [!NOTE]
> 作業中のため、wip, draftとしている

transitionの適応

## 適応の仕方
- tailwind config に設定を追加、transitionが適応・調整できるよう実装

## 対象
実装したものにチェックを入れている。

- [ ] button
- [ ] checkbox
- [ ] dropdown
- [ ] evaluation-star
- [ ] icon-button
- [ ] modal
- [ ] radio
- [ ] search
- [ ] select
- [ ] select-sort
- [ ] tab
- [ ] text-area
- [ ] text-input
- [ ] toast
- [ ] toggle
- [ ] tooltip

## 種別

### ＜出現＞
- tailwind config に設定し appear-in 、 appear-out が使用される
- toast の実装を参考に以下閉じる流れで組んだ

setIsRemoving(true)  → 
非表示のcssが適応される  →
onAnimationEnd で opacity=0 を確認し →
閉じる完了

### ＜ホバー＞
- classに、transition-colors + animate-hover-over or animate-hover-out の組み合わせを適応する
- tailwind config に設定し animate-hover-over 、 animate-hover-out が使用される

## 資料

以下切り口で資料をまとめている
- transition 適応対象のコンポーネント
- transition 適応対象”外”のコンポーネント
- 出現 の対象のコンポーネント
- ホバー の対象のコンポーネント

Notion
https://www.notion.so/zenkigen/abcbd5f0371c4f5eb8b1decfd79fb8ab?v=b0cfaabb515348158e38ccb46517588f

全体資料：Notion
https://www.notion.so/zenkigen/ZEN-trasition-db07cf4cf9b64e14a2ea9b44a16c856f