### PR TITLE
feat: add style to tooltips

### DIFF
--- a/packages/component-ui/src/tooltip/tooltip-content.tsx
+++ b/packages/component-ui/src/tooltip/tooltip-content.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import type { CSSProperties } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
 
 import { TailIcon } from './tail-icon';
 import type { TooltipHorizontalAlign, TooltipPosition, TooltipSize, TooltipVerticalPosition } from './type';
@@ -13,7 +13,7 @@ export const TooltipContent = ({
   maxWidth,
   isPortal = false,
 }: {
-  content: string;
+  content: ReactNode;
   size: TooltipSize;
   maxWidth: CSSProperties['maxWidth'];
   verticalPosition: TooltipVerticalPosition;
@@ -58,7 +58,6 @@ export const TooltipContent = ({
         className={tooltipBodyClasses}
         style={{
           maxWidth,
-          whiteSpace: 'pre-wrap',
         }}
       >
         {content}

--- a/packages/component-ui/src/tooltip/tooltip-content.tsx
+++ b/packages/component-ui/src/tooltip/tooltip-content.tsx
@@ -58,6 +58,7 @@ export const TooltipContent = ({
         className={tooltipBodyClasses}
         style={{
           maxWidth,
+          whiteSpace: 'pre-wrap',
         }}
       >
         {content}

--- a/packages/component-ui/src/tooltip/tooltip.stories.tsx
+++ b/packages/component-ui/src/tooltip/tooltip.stories.tsx
@@ -26,7 +26,13 @@ type Story = StoryObj<typeof Tooltip>;
 
 export const Base: Story = {
   args: {
-    content: '内容説明テキスト',
+    content: (
+      <>
+        内容説明テキスト1
+        <br />
+        内容説明テキスト2
+      </>
+    ),
   },
   render: (args) => (
     <div className="grid gap-10 px-20 py-10">
@@ -48,32 +54,6 @@ export const Portal: Story = {
   args: {
     portalTarget: document.body,
     content: '内容説明テキスト',
-  },
-  render: (args) => (
-    <div className="grid gap-10 px-20 py-10">
-      <div className="flex items-center gap-20">
-        <Tooltip {...args}>
-          <div className="flex h-10 w-24 items-center justify-center rounded border border-gray-400">target</div>
-        </Tooltip>
-      </div>
-      <div className="flex items-center gap-20">
-        <Tooltip {...args}>
-          <div className="flex h-10 w-[240px] items-center justify-center rounded border border-gray-400">target</div>
-        </Tooltip>
-      </div>
-    </div>
-  ),
-};
-
-export const WithLineBreak: Story = {
-  args: {
-    content: (
-      <>
-        行1
-        <br />
-        行2
-      </>
-    ),
   },
   render: (args) => (
     <div className="grid gap-10 px-20 py-10">

--- a/packages/component-ui/src/tooltip/tooltip.stories.tsx
+++ b/packages/component-ui/src/tooltip/tooltip.stories.tsx
@@ -64,3 +64,28 @@ export const Portal: Story = {
     </div>
   ),
 };
+
+export const WithLineBreak: Story = {
+  args: {
+    content: (
+      <>
+        行1<br />
+        行2
+      </>
+    )
+  },
+  render: (args) => (
+    <div className="grid gap-10 px-20 py-10">
+      <div className="flex items-center gap-20">
+        <Tooltip {...args}>
+          <div className="flex h-10 w-24 items-center justify-center rounded border border-gray-400">target</div>
+        </Tooltip>
+      </div>
+      <div className="flex items-center gap-20">
+        <Tooltip {...args}>
+          <div className="flex h-10 w-[240px] items-center justify-center rounded border border-gray-400">target</div>
+        </Tooltip>
+      </div>
+    </div>
+  ),
+};

--- a/packages/component-ui/src/tooltip/tooltip.stories.tsx
+++ b/packages/component-ui/src/tooltip/tooltip.stories.tsx
@@ -69,10 +69,11 @@ export const WithLineBreak: Story = {
   args: {
     content: (
       <>
-        行1<br />
+        行1
+        <br />
         行2
       </>
-    )
+    ),
   },
   render: (args) => (
     <div className="grid gap-10 px-20 py-10">

--- a/packages/component-ui/src/tooltip/tooltip.tsx
+++ b/packages/component-ui/src/tooltip/tooltip.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties, PropsWithChildren } from 'react';
+import type { CSSProperties, PropsWithChildren, ReactNode } from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
@@ -7,7 +7,7 @@ import { TooltipContent } from './tooltip-content';
 import type { TooltipHorizontalAlign, TooltipPosition, TooltipSize, TooltipVerticalPosition } from './type';
 
 type Props = {
-  content: string;
+  content: ReactNode;
   size?: TooltipSize;
   maxWidth?: CSSProperties['maxWidth'];
   verticalPosition?: TooltipVerticalPosition;


### PR DESCRIPTION
~~tooltip内で改行できるようにするために、pre-wrapのスタイルを追加した。~~

pre-wrapは影響が大きすぎるため、content を ReactNode にして使用するコンポーネント側で br タグを差し込む形に変更。

