### PR TITLE
Pagination: Figmaとのstyle差分修正

### DIFF
--- a/packages/component-ui/src/pagination/pagination-button.tsx
+++ b/packages/component-ui/src/pagination/pagination-button.tsx
@@ -1,6 +1,6 @@
+import { clsx } from 'clsx';
 import { useContext } from 'react';
 
-import { Button } from '../button';
 import { PaginationContext } from './pagination-context';
 
 type Props = {
@@ -11,9 +11,17 @@ type Props = {
 export function PaginationButton({ page, onClick }: Props) {
   const { currentPage } = useContext(PaginationContext);
 
+  const buttonClasses = clsx(
+    'flex h-8 min-w-8 items-center justify-center rounded fill-icon01 px-1',
+    'typography-label2regular',
+    'hover:bg-hover02',
+    { 'border border-uiBorder02 text-text01': page === currentPage },
+    { 'border-transparent text-interactive02': page !== currentPage },
+  );
+
   return (
-    <Button variant={page === currentPage ? 'outline' : 'text'} onClick={() => onClick(page)}>
+    <button type="button" className={buttonClasses} onClick={() => onClick(page)}>
       {page}
-    </Button>
+    </button>
   );
 }

--- a/packages/component-ui/src/pagination/pagination-button.tsx
+++ b/packages/component-ui/src/pagination/pagination-button.tsx
@@ -14,9 +14,10 @@ export function PaginationButton({ page, onClick }: Props) {
   const buttonClasses = clsx(
     'flex h-8 min-w-8 items-center justify-center rounded fill-icon01 px-1',
     'typography-label2regular',
+    'text-interactive02',
     'hover:bg-hover02',
-    { 'border border-uiBorder02 text-text01': page === currentPage },
-    { 'border-transparent text-interactive02': page !== currentPage },
+    { 'border border-uiBorder02': page === currentPage },
+    { 'border-transparent': page !== currentPage },
   );
 
   return (

--- a/packages/component-ui/src/pagination/pagination.stories.tsx
+++ b/packages/component-ui/src/pagination/pagination.stories.tsx
@@ -24,7 +24,7 @@ type Story = StoryObj<typeof Pagination>;
 export const Base: Story = {
   args: {
     currentPage: 1,
-    totalPage: 20,
+    totalPage: 200,
     sideNumPagesToShow: 4,
   },
   render: function MyFunc({ ...args }) {

--- a/packages/component-ui/src/pagination/pagination.tsx
+++ b/packages/component-ui/src/pagination/pagination.tsx
@@ -39,12 +39,12 @@ export function Pagination({ currentPage, totalPage, sideNumPagesToShow = 3, onC
       }}
     >
       <ul className="flex gap-1">
-        <li>
+        <li className="flex items-center">
           <IconButton
             isDisabled={currentPage === START_PAGE}
             variant="text"
             icon="angle-left"
-            size="medium"
+            size="small"
             onClick={() => onClick(currentPage - 1)}
           />
         </li>
@@ -69,12 +69,12 @@ export function Pagination({ currentPage, totalPage, sideNumPagesToShow = 3, onC
         <li>
           <PaginationButton onClick={() => onClick(totalPage)} page={totalPage} />
         </li>
-        <li>
+        <li className="flex items-center">
           <IconButton
             isDisabled={currentPage === totalPage}
             variant="text"
             icon="angle-right"
-            size="medium"
+            size="small"
             onClick={() => onClick(currentPage + 1)}
           />
         </li>

--- a/packages/component-ui/src/pagination/pagination.tsx
+++ b/packages/component-ui/src/pagination/pagination.tsx
@@ -38,7 +38,7 @@ export function Pagination({ currentPage, totalPage, sideNumPagesToShow = 3, onC
         currentPage,
       }}
     >
-      <ul className="flex gap-2">
+      <ul className="flex gap-1">
         <li>
           <IconButton
             isDisabled={currentPage === START_PAGE}


### PR DESCRIPTION
デザインレビューで確認・相談したstyle差分の修正です
・ボタンのwidthを`with可変=hug + padding: 4px + min-width: 32px`に修正
　（これに伴いButtonコンポーネントは使わないかたちにした）
・ボタン間のgapを4pxに修正
・両端のangleアイコンのサイズを修正
・数字3桁の場合を確認できるようにstoryを修正

修正前
![スクリーンショット 2024-05-21 13 31 42](https://github.com/zenkigen/zenkigen-component/assets/8681045/a460b065-2036-4309-9c55-c622b3e3cf89)


修正後
![スクリーンショット 2024-05-21 13 58 46](https://github.com/zenkigen/zenkigen-component/assets/8681045/5d8a57d5-871b-4cc7-90b0-0a3d171ba814)




