### PR TITLE
TextInput: Figmaとのstyle差分修正

### DIFF
--- a/packages/component-ui/src/text-input/text-input.tsx
+++ b/packages/component-ui/src/text-input/text-input.tsx
@@ -25,8 +25,8 @@ export const TextInput = forwardRef<HTMLInputElement, Props>(
     const inputClasses = clsx(
       'flex-1 pl-2 pr-3 outline-0 placeholder:text-textPlaceholder disabled:text-textPlaceholder',
       {
-        ['typography-label2regular pt-1.5 pb-2']: size === 'medium',
-        ['typography-label1regular py-2.5']: size === 'large',
+        ['typography-label2regular h-8']: size === 'medium',
+        ['typography-label1regular h-10']: size === 'large',
         'text-text01': !isError,
         'text-supportError': isError,
       },

--- a/packages/component-ui/src/text-input/text-input.tsx
+++ b/packages/component-ui/src/text-input/text-input.tsx
@@ -14,7 +14,7 @@ type Props = Omit<InputHTMLAttributes<HTMLInputElement>, 'size'> & {
 export const TextInput = forwardRef<HTMLInputElement, Props>(
   ({ size = 'medium', isError = false, disabled = false, onClickClearButton, ...props }: Props, ref) => {
     const inputWrapClasses = clsx('relative flex items-center gap-2 overflow-hidden rounded border', {
-      'border-uiBorder01': !isError,
+      'border-uiBorder02': !isError && !disabled,
       'border-supportError': isError && !disabled,
       'hover:border-hoverInput': !disabled && !isError,
       'hover:focus-within:border-activeInput': !isError,

--- a/packages/component-ui/src/text-input/text-input.tsx
+++ b/packages/component-ui/src/text-input/text-input.tsx
@@ -25,8 +25,8 @@ export const TextInput = forwardRef<HTMLInputElement, Props>(
     const inputClasses = clsx(
       'flex-1 pl-2 pr-3 outline-0 placeholder:text-textPlaceholder disabled:text-textPlaceholder',
       {
-        ['typography-label2regular h-8']: size === 'medium',
-        ['typography-label1regular h-10']: size === 'large',
+        ['typography-label2regular min-h-8']: size === 'medium',
+        ['typography-label1regular min-h-10']: size === 'large',
         'text-text01': !isError,
         'text-supportError': isError,
       },


### PR DESCRIPTION
デザインレビューで確認・相談したstyle差分の修正です
・borderのカラートークン修正：uiBorder01 → uiBorder02
・inputの高さをheightで指定するように修正

修正前
![スクリーンショット 2024-05-21 14 47 05](https://github.com/zenkigen/zenkigen-component/assets/8681045/b4f20ed5-cdcd-4c81-932e-4ce350da85a0)

修正後
![スクリーンショット 2024-05-21 14 46 38](https://github.com/zenkigen/zenkigen-component/assets/8681045/a33cc399-2cc0-4b7a-8b9f-fe041b33c1bf)
