### PR TITLE
TextArea: Figmaとのstyle差分修正

### DIFF
--- a/packages/component-ui/src/text-area/text-area.tsx
+++ b/packages/component-ui/src/text-area/text-area.tsx
@@ -17,7 +17,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, Props>(
       {
         'border-supportError': isError && !disabled,
         'hover:border-hoverInput': !disabled && !isError,
-        'border-uiBorder01 hover:focus-within:border-activeInput focus-within:border-activeInput text-text01': !isError,
+        'border-uiBorder02 hover:focus-within:border-activeInput focus-within:border-activeInput text-text01': !isError,
         'bg-disabled02 border-disabled01': disabled,
         ['typography-body1regular px-2 pt-1.5 pb-2']: size === 'medium',
         ['text-4 px-3.5 py-2.5']: size === 'large',

--- a/packages/component-ui/src/text-area/text-area.tsx
+++ b/packages/component-ui/src/text-area/text-area.tsx
@@ -20,7 +20,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, Props>(
         'border-uiBorder02 hover:focus-within:border-activeInput focus-within:border-activeInput text-text01': !isError,
         'bg-disabled02 border-disabled01': disabled,
         ['typography-body1regular px-2 pt-1.5 pb-2']: size === 'medium',
-        ['text-4 px-3.5 py-2.5']: size === 'large',
+        ['text-4 leading-normal px-3.5 py-2.5']: size === 'large',
         'text-supportError': isError,
         'resize-none': !isResizable,
       },


### PR DESCRIPTION
デザインレビューで確認・相談したstyle差分の修正です
・borderのカラートークン修正：uiBorder01 → uiBorder02
・size="large"の場合のline-heightを明示的に1.5に指定
　（Typographyトークンが足りない件は別途修正予定）

修正前
![スクリーンショット 2024-05-21 15 25 00](https://github.com/zenkigen/zenkigen-component/assets/8681045/31d1d3e2-3bcb-4b69-be37-413ecee04785)

修正後
![スクリーンショット 2024-05-21 15 25 26](https://github.com/zenkigen/zenkigen-component/assets/8681045/e2350664-ef37-4b7d-9f7f-7a1667131cc2)
