### PR TITLE
Use esm

### DIFF
--- a/packages/component-config/src/index.ts
+++ b/packages/component-config/src/index.ts
@@ -1,1 +1,1 @@
-export * from './tailwind-config';
+export { tailwindConfig as default } from './tailwind-config'

--- a/packages/component-config/src/tailwind-config.ts
+++ b/packages/component-config/src/tailwind-config.ts
@@ -22,7 +22,7 @@ const {
   colors,
 } = tokens;
 
-export default {
+export const tailwindConfig = {
   theme: {
     extend: {
       fontFamily: {

--- a/packages/component-config/src/tailwind-config.ts
+++ b/packages/component-config/src/tailwind-config.ts
@@ -22,7 +22,7 @@ const {
   colors,
 } = tokens;
 
-module.exports = {
+export const tailwindConfig = {
   theme: {
     extend: {
       fontFamily: {

--- a/packages/component-config/src/tailwind-config.ts
+++ b/packages/component-config/src/tailwind-config.ts
@@ -22,7 +22,7 @@ const {
   colors,
 } = tokens;
 
-export const tailwindConfig = {
+export default {
   theme: {
     extend: {
       fontFamily: {


### PR DESCRIPTION
以下のようなエラーが出るので対応しました。
```
Error: ES Modules may not assign module.exports or exports.*, Use ESM export syntax, instead: (rsc)/./node_modules/.pnpm/@zenkigen-inc+component-config@1.10.2/node_modules/@zenkigen-inc/component-config/dist/index.js
```

ESMの中でCJSの文法（module.exports）を使うことが原因なので、ESMを使うように修正しました。