### PR TITLE
Reactをビルド生成物から取り除く

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -27,7 +27,7 @@ jobs:
         run: yarn install
 
       - name: Build npm package
-        run: yarn build:all
+        run: yarn build-lib:all
 
       - name: Publish npm package
         run: yarn publish:all

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,13 +1,14 @@
-import { fixupConfigRules, fixupPluginRules } from '@eslint/compat';
-import simpleImportSort from 'eslint-plugin-simple-import-sort';
-import react from 'eslint-plugin-react';
-import typescriptEslint from '@typescript-eslint/eslint-plugin';
-import globals from 'globals';
-import tsParser from '@typescript-eslint/parser';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import js from '@eslint/js';
+
+import { fixupConfigRules, fixupPluginRules } from '@eslint/compat';
 import { FlatCompat } from '@eslint/eslintrc';
+import js from '@eslint/js';
+import typescriptEslint from '@typescript-eslint/eslint-plugin';
+import tsParser from '@typescript-eslint/parser';
+import react from 'eslint-plugin-react';
+import simpleImportSort from 'eslint-plugin-simple-import-sort';
+import globals from 'globals';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -19,7 +20,7 @@ const compat = new FlatCompat({
 
 export default [
   {
-    ignores: ['packages/component-ui/dist'],
+    ignores: ['packages/component-ui/dist', 'packages/component-config/dist'],
   },
   ...fixupConfigRules(
     compat.extends(

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint:fix": "eslint './packages/**/*.ts{,x}' --fix && prettier --write .",
     "type-check": "yarn workspaces foreach --all --exclude zenkigen-component run type-check",
     "build:all": "yarn workspaces foreach --all -pt --exclude zenkigen-component run build",
+    "build-lib:all": "yarn workspaces foreach --all -pt --exclude zenkigen-component run build-lib",
     "publish:all": "yarn workspaces foreach --all --exclude zenkigen-component npm publish",
     "storybook": "storybook dev",
     "create-component": "yarn workspace @zenkigen-inc/component-ui hygen generator components",

--- a/packages/component-config/package.json
+++ b/packages/component-config/package.json
@@ -14,7 +14,8 @@
   "scripts": {
     "type-check": "tsc --noEmit",
     "build:tokens": "token-transformer style-dictionary/tokens.json style-dictionary/transformed-tokens.json && node build.cjs",
-    "build": "rimraf dist && microbundle --no-compress -f modern,esm,cjs"
+    "build": "rimraf dist && microbundle --no-compress -f modern,esm,cjs",
+    "build-lib": "rimraf dist && microbundle --no-compress -f modern,esm,cjs"
   },
   "devDependencies": {
     "microbundle": "0.15.1",

--- a/packages/component-config/src/index.ts
+++ b/packages/component-config/src/index.ts
@@ -1,1 +1,1 @@
-export { tailwindConfig as default } from './tailwind-config'
+export { tailwindConfig as default } from './tailwind-config';

--- a/packages/component-config/src/index.ts
+++ b/packages/component-config/src/index.ts
@@ -1,1 +1,1 @@
-export * from './tailwind-config';
+export { tailwindConfig as default } from './tailwind-config'

--- a/packages/component-config/src/tailwind-config.ts
+++ b/packages/component-config/src/tailwind-config.ts
@@ -22,7 +22,7 @@ const {
   colors,
 } = tokens;
 
-export default {
+export const tailwindConfig = {
   theme: {
     extend: {
       fontFamily: {

--- a/packages/component-config/src/tailwind-config.ts
+++ b/packages/component-config/src/tailwind-config.ts
@@ -22,7 +22,7 @@ const {
   colors,
 } = tokens;
 
-module.exports = {
+export const tailwindConfig = {
   theme: {
     extend: {
       fontFamily: {

--- a/packages/component-config/src/tailwind-config.ts
+++ b/packages/component-config/src/tailwind-config.ts
@@ -22,7 +22,7 @@ const {
   colors,
 } = tokens;
 
-export const tailwindConfig = {
+export default {
   theme: {
     extend: {
       fontFamily: {

--- a/packages/component-icons/package.json
+++ b/packages/component-icons/package.json
@@ -13,12 +13,17 @@
   "exports": "./dist/index.js",
   "scripts": {
     "generate": "node ./codegen.cjs",
-    "build": "rimraf dist && yarn generate && microbundle --no-compress -f modern,esm,cjs --jsx React.createElement --jsxFragment React.Fragment --jsxImportSource react --globals react/jsx-runtime=jsx"
+    "build": "rimraf dist && yarn generate && microbundle --no-compress -f modern,esm,cjs --jsx React.createElement --jsxFragment React.Fragment --jsxImportSource react --globals react/jsx-runtime=jsx  --external none",
+    "build-lib": "rimraf dist && yarn generate && microbundle --no-compress -f modern,esm,cjs --jsx React.createElement --jsxFragment React.Fragment --jsxImportSource react --globals react/jsx-runtime=jsx"
   },
   "devDependencies": {
     "cheerio": "1.0.0",
     "ejs": "3.1.10",
     "microbundle": "0.15.1",
     "typescript": "5.5.4"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   }
 }

--- a/packages/component-theme/package.json
+++ b/packages/component-theme/package.json
@@ -13,7 +13,8 @@
   "exports": "./dist/index.js",
   "scripts": {
     "type-check": "tsc --noEmit",
-    "build": "rimraf dist && microbundle --no-compress -f modern,esm,cjs"
+    "build": "rimraf dist && microbundle --no-compress -f modern,esm,cjs",
+    "build-lib": "rimraf dist && microbundle --no-compress -f modern,esm,cjs"
   },
   "devDependencies": {
     "microbundle": "0.15.1",

--- a/packages/component-ui/package.json
+++ b/packages/component-ui/package.json
@@ -14,7 +14,8 @@
   "scripts": {
     "type-check": "tsc --noEmit",
     "generate-component": "hygen generator components",
-    "build": "rimraf dist && microbundle --no-compress -f modern,esm,cjs --jsx React.createElement --jsxFragment React.Fragment --jsxImportSource react --globals react/jsx-runtime=jsx --tsconfig tsconfig.build.json"
+    "build": "rimraf dist && microbundle --no-compress -f modern,esm,cjs --jsx React.createElement --jsxFragment React.Fragment --jsxImportSource react --globals react/jsx-runtime=jsx --tsconfig tsconfig.build.json --external none",
+    "build-lib": "rimraf dist && microbundle --no-compress -f modern,esm,cjs --jsx React.createElement --jsxFragment React.Fragment --jsxImportSource react --globals react/jsx-runtime=jsx --tsconfig tsconfig.build.json"
   },
   "devDependencies": {
     "hygen": "6.2.11",
@@ -22,8 +23,8 @@
     "typescript": "5.5.4"
   },
   "peerDependencies": {
-    "@types/react": "^18.0.0",
-    "react": "^18.0.0"
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   },
   "dependencies": {
     "@zenkigen-inc/component-icons": "1.10.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3338,6 +3338,9 @@ __metadata:
     ejs: "npm:3.1.10"
     microbundle: "npm:0.15.1"
     typescript: "npm:5.5.4"
+  peerDependencies:
+    react: ^18.0.0
+    react-dom: ^18.0.0
   languageName: unknown
   linkType: soft
 
@@ -3362,8 +3365,8 @@ __metadata:
     microbundle: "npm:0.15.1"
     typescript: "npm:5.5.4"
   peerDependencies:
-    "@types/react": ^18.0.0
     react: ^18.0.0
+    react-dom: ^18.0.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
- reactとreact-domをpeerdependenciesに追加する
- ビルドコマンドを2つ用意する
  - storybook用: `yarn build` `yarn build:all`
  - ライブラリ用: `yarn build-lib` `yarn build-lib:all`