### PR TITLE
61：Button：variant outline 背景色を白に修正

### DIFF
--- a/packages/component-theme/src/colors.ts
+++ b/packages/component-theme/src/colors.ts
@@ -27,7 +27,7 @@ export const buttonColors = {
     selected: 'border border-transparent bg-supportDangerLight text-supportDanger fill-supportDanger',
   },
   outline: {
-    base: 'border border-uiBorder02 text-interactive02 fill-interactive02',
+    base: 'border border-uiBorder02 bg-uiBackground01 text-interactive02 fill-interactive02',
     hover: 'hover:bg-hover02',
     active: 'active:bg-active02',
     disabled: 'disabled:border-uiBorder01 disabled:text-disabled01 disabled:fill-disabled01',


### PR DESCRIPTION
### 概要

＜問題＞

- Button コンポーネント
- variant outline
- 背景色が透明になっている

＜対応したこと＞

- 背景色をUiBackground01（#FFF）に設定
- component-theme の設定により適応されていた部分
- その修正を行った

### 詳細

| Before | After |
| --- | --- |
| <img width="956" alt="image" src="https://github.com/user-attachments/assets/9876cfd6-fe2a-41bc-9317-267f13501dcc" /> | <img width="957" alt="image" src="https://github.com/user-attachments/assets/3ec2e220-8835-4784-b08f-324e34d0dfda" /> |