### PR TITLE
35｜Tab｜Update hover background color for unselected tabs

### DIFF
--- a/packages/component-ui/src/tab/tab-item.tsx
+++ b/packages/component-ui/src/tab/tab-item.tsx
@@ -14,7 +14,7 @@ export const TabItem = ({ isSelected = false, ...props }: Props) => {
     'relative z-0 flex py-2 leading-[24px] before:absolute before:inset-x-0 before:bottom-0 before:h-px hover:text-text01 disabled:pointer-events-none disabled:text-disabled01',
     {
       'typography-label14regular': !isSelected,
-      'text-interactive02 hover:before:bg-uiBorder02Dark': !isSelected,
+      'text-interactive02 hover:before:bg-uiBorder04': !isSelected,
       'typography-label14bold': isSelected,
       'before:bg-interactive01 hover:before:bg-interactive01 pointer-events-none': isSelected,
     },


### PR DESCRIPTION
### 概要

Notion資料の②の部分

- Tab（未選択状態の）のホバー時の下線の色の token 変更
- 表示上の変更はなし（変更後のTokenが、元のTokenとカラーが同一のため）

<!-- I want to review in Japanese. -->

<!-- I want to review in Japanese. -->