### PR TITLE
98｜Icon｜refactor: remove dark icon variants from Icon component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,6 @@ storybook-static
 
 # macOS
 .DS_Store*
+
+# Cursor
+.cursor/

--- a/.gitignore
+++ b/.gitignore
@@ -111,6 +111,3 @@ storybook-static
 
 # macOS
 .DS_Store*
-
-# Cursor
-.cursor/

--- a/packages/component-theme/src/colors.ts
+++ b/packages/component-theme/src/colors.ts
@@ -44,11 +44,8 @@ export const buttonColors = {
 
 export const iconColors = {
   icon01: 'fill-icon01',
-  icon01Dark: 'fill-icon01Dark',
   icon02: 'fill-icon02',
-  icon02Dark: 'fill-icon02Dark',
   icon03: 'fill-icon03',
-  icon03Dark: 'fill-icon03Dark',
   iconOnColor: 'fill-iconOnColor',
 } as const;
 

--- a/packages/component-ui/src/icon/icon.stories.tsx
+++ b/packages/component-ui/src/icon/icon.stories.tsx
@@ -135,12 +135,6 @@ export function Color() {
       <IconList color="icon02" />
       <div>icon03:</div>
       <IconList color="icon03" />
-      <div>icon01Dark:</div>
-      <IconList color="icon01Dark" className="bg-uiBackground01Dark" />
-      <div>icon02Dark:</div>
-      <IconList color="icon02Dark" className="bg-uiBackground01Dark" />
-      <div>icon03Dark:</div>
-      <IconList color="icon03Dark" className="bg-uiBackground01Dark" />
       <div>iconOnColor:</div>
       <IconList color="iconOnColor" className="bg-interactive01" />
     </div>

--- a/packages/component-ui/src/icon/icon.tsx
+++ b/packages/component-ui/src/icon/icon.tsx
@@ -21,11 +21,8 @@ export const Icon = ({ size = 'medium', isDisabled = false, ...props }: Props) =
     {
       'fill-disabled01': isDisabled,
       [iconColors.icon01]: !isDisabled && props.color === 'icon01',
-      [iconColors.icon01Dark]: !isDisabled && props.color === 'icon01Dark',
       [iconColors.icon02]: !isDisabled && props.color === 'icon02',
-      [iconColors.icon02Dark]: !isDisabled && props.color === 'icon02Dark',
       [iconColors.icon03]: !isDisabled && props.color === 'icon03',
-      [iconColors.icon03Dark]: !isDisabled && props.color === 'icon03Dark',
       [iconColors.iconOnColor]: !isDisabled && props.color === 'iconOnColor',
       'w-3 h-3': size === 'x-small',
       'w-4 h-4': size === 'small',


### PR DESCRIPTION
## 概要
Icon コンポーネントから Dark variant の色指定 (icon01Dark, icon02Dark, icon03Dark) を削除

## 変更内容
- `packages/component-theme/src/colors.ts` から iconColors オブジェクトの Dark 関連プロパティを削除 (icon01Dark, icon02Dark, icon03Dark)
- `packages/component-ui/src/icon/icon.tsx` の Icon コンポーネントから Dark variant の条件付きクラスを削除
- `packages/component-ui/src/icon/icon.stories.tsx` の Storybook の例からも Dark variant の表示部分を削除

## 備考
- Design token 自体からは Dark variant は削除していません (他のコンポーネントでの使用の可能性があるため)
- Color type は `keyof typeof iconColors` として定義されているため、Dark variant 削除後は自動的に型から削除されます


<!-- I want to review in Japanese. -->
<!-- I want to review in Japanese. -->