### PR TITLE
Revert "Revert "64: text-input: Fix overlap between clear button and input text in TextInput component""

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -12,5 +12,6 @@ const preview: Preview = {
       },
     },
   },
+  tags: ['autodocs'],
 };
 export default preview;

--- a/packages/component-ui/src/text-input/text-input.stories.tsx
+++ b/packages/component-ui/src/text-input/text-input.stories.tsx
@@ -34,12 +34,15 @@ export const Base: Story = {
   },
   render: function MyFunc({ ...args }) {
     const [value, setValue] = useState<string>(args.value);
-    const [value2, setValue2] = useState<string>('入力した文字列。');
+    const [value2, setValue2] = useState<string>(
+      '入力文字列入力文字列入力文字列入力文字列入力文字列入力文字列入力文字列入力文字列',
+    );
     const [valueNumber, setValueNumber] = useState<string>('123');
     const [valuePassword, setValuePassword] = useState<string>('abcdefg');
 
     return (
       <div className="flex gap-10">
+        {/* サイズ：medium */}
         <div style={{ width: 300 }} className="flex flex-col gap-12">
           <div>
             <TextInput
@@ -145,7 +148,20 @@ export const Base: Story = {
               type="password"
             />
           </div>
+          <div>
+            <TextInput
+              value={value}
+              placeholder="入力してください"
+              size="medium"
+              onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                action('onChange')(e);
+                setValue(e.target.value);
+              }}
+            />
+            <ErrorText>クリアボタンなし</ErrorText>
+          </div>
         </div>
+        {/* サイズ：large */}
         <div style={{ width: 300 }} className="flex flex-col gap-10">
           <div>
             <TextInput
@@ -251,6 +267,18 @@ export const Base: Story = {
               }}
               type="password"
             />
+          </div>
+          <div>
+            <TextInput
+              value={value}
+              placeholder="入力してください"
+              size="large"
+              onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                action('onChange')(e);
+                setValue(e.target.value);
+              }}
+            />
+            <ErrorText>クリアボタンなし</ErrorText>
           </div>
         </div>
       </div>

--- a/packages/component-ui/src/text-input/text-input.tsx
+++ b/packages/component-ui/src/text-input/text-input.tsx
@@ -13,6 +13,7 @@ type Props = Omit<InputHTMLAttributes<HTMLInputElement>, 'size'> & {
 
 export const TextInput = forwardRef<HTMLInputElement, Props>(
   ({ size = 'medium', isError = false, disabled = false, onClickClearButton, ...props }: Props, ref) => {
+    const isShowClearButton = !!onClickClearButton && props.value.length !== 0 && !disabled;
     const inputWrapClasses = clsx('relative flex items-center gap-2 overflow-hidden rounded border', {
       'border-uiBorder02': !isError && !disabled,
       'border-supportError': isError && !disabled,
@@ -20,26 +21,22 @@ export const TextInput = forwardRef<HTMLInputElement, Props>(
       'hover:focus-within:border-activeInput': !isError,
       'focus-within:border-activeInput': !isError,
       'bg-disabled02 border-disabled01': disabled,
+      'pr-2': size === 'medium' && isShowClearButton,
+      'pr-3': size === 'large' && isShowClearButton,
     });
 
-    const inputClasses = clsx(
-      'flex-1 pl-2 pr-3 outline-0 placeholder:text-textPlaceholder disabled:text-textPlaceholder',
-      {
-        ['typography-label14regular min-h-8']: size === 'medium',
-        ['typography-label16regular min-h-10']: size === 'large',
-        'text-text01': !isError,
-        'text-supportError': isError,
-      },
-    );
+    const inputClasses = clsx('flex-1 outline-0 placeholder:text-textPlaceholder disabled:text-textPlaceholder', {
+      ['typography-label14regular min-h-8 px-2']: size === 'medium',
+      ['typography-label16regular min-h-10 px-3']: size === 'large',
+      'text-text01': !isError,
+      'text-supportError': isError,
+      'pr-0': isShowClearButton,
+    });
 
     return (
       <div className={inputWrapClasses}>
         <input ref={ref} size={1} className={inputClasses} disabled={disabled} onChange={props.onChange} {...props} />
-        {onClickClearButton && props.value.length !== 0 && !disabled && (
-          <div className="absolute right-3">
-            <IconButton variant="text" icon="close" size="small" isNoPadding onClick={onClickClearButton} />
-          </div>
-        )}
+        {isShowClearButton && <IconButton variant="text" icon="close" size="small" onClick={onClickClearButton} />}
       </div>
     );
   },


### PR DESCRIPTION
## 概要
リバートされた「64: text-input: Fix overlap between clear button and input text in TextInput component」の修正を復活させます。テキスト入力とクリアボタンが重なる問題を再度修正します。

| 項目 | 内容 |
| --- | --- |
| 後方互換性 | あり |
| デザインビューの必要性 | なし |

## 変更内容
コミット c168c0d831fef9d94a3812d388e7d55b9824e207 で行われたリバートを取り消し、TextInputコンポーネントにおけるクリアボタンとテキスト入力が重なる問題の修正を復活させます。

- text-input.tsx: クリアボタンとテキスト入力の配置を調整
- text-input.stories.tsx: テストケースの復活

## 備考
特になし
