### PR TITLE
Chromaticデプロイメントジョブの実行条件の変更

### DIFF
--- a/.github/workflows/chromatic.yaml
+++ b/.github/workflows/chromatic.yaml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   chromatic-deployment:
-    if: github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'renovate') == false
+    if: github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'renovate') == false && contains(github.event.pull_request.labels.*.name, 'dependencies') == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## 条件の詳細
**1. github.event.pull_request.draft == false**
意味: プルリクエストがドラフト状態ではない
目的: ドラフトPRではChromaticテストを実行しない（開発中のため）
**2. contains(github.event.pull_request.labels.*.name, 'renovate') == false**
意味: プルリクエストにrenovateラベルが付いていない
目的: Renovateボット（依存関係自動更新ツール）によるPRではChromaticテストをスキップ
**3. contains(github.event.pull_request.labels.*.name, 'dependencies') == false**
意味: プルリクエストにdependenciesラベルが付いていない
目的: 依存関係更新のPRではChromaticテストをスキップ