### PR TITLE
32, 94｜ColorToken, Toggle｜feat: add hoverGray token and apply to Toggle hover state

### DIFF
--- a/packages/component-config/src/tokens/tokens.ts
+++ b/packages/component-config/src/tokens/tokens.ts
@@ -125,7 +125,8 @@ export const tokens = {
       "hoverLink01": "#1366B9",
       "hoverLink01Dark": "#9FCBF5",
       "hoverLink02": "#6F7476",
-      "hoverLink02Dark": "#DEDFE0"
+      "hoverLink02Dark": "#DEDFE0",
+      "hoverGray": "#454A4D"
     },
     "active": {
       "active01": "#0E4B87",

--- a/packages/component-config/style-dictionary/tokens.json
+++ b/packages/component-config/style-dictionary/tokens.json
@@ -534,6 +534,11 @@
           "value": "$Colors.Gray.Gray30",
           "type": "color",
           "description": "hover secondary link - Dark"
+        },
+        "HoverGray": {
+          "value": "$Colors.Gray.Gray90",
+          "type": "color",
+          "description": "Hover Checkbox, Toggle"
         }
       },
       "Active": {

--- a/packages/component-config/style-dictionary/transformed-tokens.json
+++ b/packages/component-config/style-dictionary/transformed-tokens.json
@@ -533,6 +533,11 @@
         "value": "#DEDFE0",
         "type": "color",
         "description": "hover secondary link - Dark"
+      },
+      "HoverGray": {
+        "value": "#454A4D",
+        "type": "color",
+        "description": "Hover Checkbox, Toggle"
       }
     },
     "Active": {

--- a/packages/component-ui/src/toggle/toggle.tsx
+++ b/packages/component-ui/src/toggle/toggle.tsx
@@ -24,7 +24,7 @@ export function Toggle({
     'bg-disabledOn': isDisabled && isChecked,
     'bg-disabled01': isDisabled && !isChecked,
     'bg-interactive01 peer-hover:bg-hover01': !isDisabled && isChecked,
-    'bg-interactive02 peer-hover:bg-hover02Dark': !isDisabled && !isChecked,
+    'bg-interactive02 peer-hover:bg-hoverGray': !isDisabled && !isChecked,
     'w-8 h-4 px-[3px]': size === 'small',
     'w-12 h-6 px-1': size === 'medium' || size === 'large',
   });


### PR DESCRIPTION
# 目的

Toggleコンポーネントの非選択時hoverカラーを新規トークン（hoverGray）に変更し、デザイン仕様に合わせるため。

# 変更内容

- 新規トークン `hoverGray` を `component-config` のtokensに追加
- style-dictionaryのjson・transformed-tokens.jsonに `HoverGray` を追加
- Toggleコンポーネントの非選択時hoverカラーを `hoverGray` に変更

# 影響範囲

- Toggleコンポーネント（`component-ui`）
- トークン管理（`component-config`）

# 動作確認

- Toggleコンポーネントの非選択時にhoverした際、指定のグレー色（#454A4D）が適用されることを確認
- 既存の他のトークン・コンポーネントへの影響がないことを確認

# 備考

- デザインシステムのガイドラインに準拠
- 追加トークンは今後他コンポーネントでも利用可能
