### PR TITLE
Update icon usage example in README

### DIFF
--- a/packages/component-icons/README.md
+++ b/packages/component-icons/README.md
@@ -66,13 +66,13 @@ yarn build:all
 
 ### 4. アイコンの利用
 
-ビルド後、追加したアイコンは `iconElements` オブジェクトから使用できます:
+ビルド後、追加したアイコンは Icon コンポーネントで利用できます:
 
 ```tsx
-import { iconElements } from '@zenkigen-inc/component-icons';
+import { Icon } from '@zenkigen-inc/component-ui';
 
 // 追加したアイコンを表示
-<div>{iconElements['new-icon-name']}</div>;
+<Icon name="new-icon-name" />;
 ```
 
 アイコン名は、ファイル名から拡張子を除いたものになります (例: `arrow-right.svg` → `'arrow-right'`)


### PR DESCRIPTION
## 概要
`packages/component-icons/README.md` のアイコン利用方法の説明を修正しました。

## 変更内容
- アイコンの利用例を `iconElements` から `Icon` コンポーネントに変更
- コード例の修正

## 背景・目的
実際の利用方法に合わせてREADMEの記述を最新化し、利用者が正しい方法でアイコンを使えるようにするため。

## 動作確認
- ドキュメントの修正のみのため、動作確認は不要です。

## その他
- 機能追加やバグ修正は含みません。
