### PR TITLE
feat: Add body scroll lock functionality to Modal component

### DIFF
--- a/packages/component-ui/src/modal/Docs.mdx
+++ b/packages/component-ui/src/modal/Docs.mdx
@@ -1,12 +1,12 @@
 import { Canvas, Meta, ArgTypes, Story, Controls, Source } from '@storybook/blocks';
-import ModalStories, { Base } from './modal.stories';
+import ModalStories, { Component } from './modal.stories';
 
 <Meta title="Modal" of={ModalStories} />
 
 # Modal
 
 <Canvas>
-  <Story of={Base} />
+  <Story of={Component} />
 </Canvas>
 
-<Controls of={Base} />
+<Controls of={Component} />

--- a/packages/component-ui/src/modal/body-scroll-lock.tsx
+++ b/packages/component-ui/src/modal/body-scroll-lock.tsx
@@ -1,0 +1,100 @@
+import { useLayoutEffect } from 'react';
+
+/**
+ * モーダル表示時にバックグラウンドのスクロールを防止するコンポーネント。
+ * コンポーネントがマウントされている間、position: fixedアプローチを使用して
+ * body要素にスクロールロックを適用します。
+ * 縦横両方のスクロール位置を保存し、コンポーネントのアンマウント時に復元します。
+ * スクロールバーの有無を検出し、その幅を考慮してレイアウトシフトを防止します。
+ * position、top、left、width、overflow、padding-rightを変更し、
+ * 最小限の変更でスクロールを防止します。
+ * グローバルCSSに依存せず、すべてインラインスタイルで実装されています。
+ * このコンポーネントは実際のDOM要素をレンダリングせず、効果のみを適用します。
+ *
+ * @example
+ * // モーダルコンポーネント内で使用する例
+ * const Modal = ({ isOpen, children }) => {
+ *   return (
+ *     <>
+ *       {isOpen && <BodyScrollLock />}
+ *       {isOpen && (
+ *         <div className="modal">
+ *           {children}
+ *         </div>
+ *       )}
+ *     </>
+ *   );
+ * };
+ */
+export const BodyScrollLock = (): null => {
+  useLayoutEffect(() => {
+    // 現在の縦横スクロール位置を記録
+    const { scrollX, scrollY } = window;
+    const { body } = document;
+
+    // スクロールバーの有無と幅を検出
+    const hasVerticalScrollbar = document.documentElement.scrollHeight > document.documentElement.clientHeight;
+    const scrollbarWidth = hasVerticalScrollbar ? window.innerWidth - document.documentElement.clientWidth : 0;
+
+    // 元のインラインスタイルの値を保存
+    const originalInlineStyles = {
+      position: body.style.position,
+      top: body.style.top,
+      left: body.style.left,
+      width: body.style.width,
+      overflow: body.style.overflow,
+      paddingRight: body.style.paddingRight,
+    };
+
+    // スクロールロックスタイルを適用
+    body.style.position = 'fixed';
+    body.style.top = `-${scrollY}px`;
+    body.style.left = `-${scrollX}px`;
+    body.style.width = '100%';
+    body.style.overflow = 'hidden';
+
+    // スクロールバーがある場合、その幅分だけpadding-rightを調整
+    if (hasVerticalScrollbar && scrollbarWidth > 0) {
+      // 現在のpadding-rightの値を取得
+      const { paddingRight } = window.getComputedStyle(body);
+      const paddingRightValue = paddingRight !== '' ? parseInt(paddingRight, 10) : 0;
+
+      // スクロールバーの幅を加算
+      body.style.paddingRight = `${paddingRightValue + scrollbarWidth}px`;
+    }
+
+    // クリーンアップ関数
+    return () => {
+      // 元のスタイル値を取得
+      const { position, top, left, width, overflow, paddingRight } = originalInlineStyles;
+
+      // プロパティごとに元の値を復元
+      restoreProperty(body, 'position', position);
+      restoreProperty(body, 'top', top);
+      restoreProperty(body, 'left', left);
+      restoreProperty(body, 'width', width);
+      restoreProperty(body, 'overflow', overflow);
+      restoreProperty(body, 'padding-right', paddingRight);
+
+      // スクロール位置を復元
+      window.scrollTo(scrollX, scrollY);
+    };
+  }, []); // 空の依存配列を指定して初回のみ実行
+
+  // DOM要素をレンダリングせず、nullを返す
+  return null;
+};
+
+/**
+ * 元のスタイル値を復元するヘルパー関数
+ * @param element スタイルを復元する要素
+ * @param property 復元するCSSプロパティ名
+ * @param value 復元する値
+ */
+function restoreProperty(element: HTMLElement, property: string, value: string): void {
+  if (value !== '') {
+    element.style.setProperty(property, value);
+  } else {
+    element.style.removeProperty(property);
+  }
+}

--- a/packages/component-ui/src/modal/modal.stories.tsx
+++ b/packages/component-ui/src/modal/modal.stories.tsx
@@ -16,6 +16,42 @@ type Story = StoryObj<typeof Modal>;
 
 export default meta;
 
+export const Component: Story = {
+  args: {
+    width: 480,
+  },
+  parameters: {
+    chromatic: { disable: true },
+  },
+  render: function MyFunc({ ...args }) {
+    const [isOpen, setIsOpen] = useState(true);
+
+    return (
+      <div>
+        <button type="button" onClick={() => setIsOpen(true)}>
+          open
+        </button>
+        <Modal isOpen={isOpen} onClose={() => setIsOpen(false)} width={args.width}>
+          <Modal.Header>タイトル</Modal.Header>
+          <Modal.Body>
+            <div className="flex w-full items-center justify-center py-20">Content</div>
+          </Modal.Body>
+          <Modal.Footer>
+            <div className="flex w-full flex-wrap items-center justify-end gap-4">
+              <Button variant="outline" size="large" onClick={action('キャンセル')}>
+                キャンセル
+              </Button>
+              <Button variant="fill" size="large" onClick={action('保存する')}>
+                保存する
+              </Button>
+            </div>
+          </Modal.Footer>
+        </Modal>
+      </div>
+    );
+  },
+};
+
 export const Base: Story = {
   args: {
     width: 480,
@@ -28,6 +64,9 @@ export const Base: Story = {
         <button type="button" onClick={() => setIsOpen(true)}>
           open
         </button>
+        {Array.from({ length: 41 }, (_, i) => (
+          <br key={i} />
+        ))}
         <Modal isOpen={isOpen} onClose={() => setIsOpen(false)} width={args.width}>
           <Modal.Header>タイトル</Modal.Header>
           <Modal.Body>

--- a/packages/component-ui/src/modal/modal.tsx
+++ b/packages/component-ui/src/modal/modal.tsx
@@ -2,6 +2,7 @@ import type { CSSProperties, MutableRefObject, PropsWithChildren } from 'react';
 import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 
+import { BodyScrollLock } from './body-scroll-lock';
 import { ModalBody } from './modal-body';
 import { ModalContext } from './modal-context';
 import { ModalFooter } from './modal-footer';
@@ -28,8 +29,10 @@ export function Modal({ children, width = 480, height, isOpen, onClose, portalTa
     setIsMounted(true);
   }, []);
 
-  return isMounted && isOpen
-    ? createPortal(
+  return isMounted && isOpen ? (
+    <>
+      <BodyScrollLock />
+      {createPortal(
         <ModalContext.Provider value={{ onClose }}>
           <div className="fixed left-0 top-0 z-overlay flex size-full items-center justify-center bg-backgroundOverlayBlack py-4">
             <div
@@ -41,8 +44,9 @@ export function Modal({ children, width = 480, height, isOpen, onClose, portalTa
           </div>
         </ModalContext.Provider>,
         portalTargetRef?.current != null ? portalTargetRef.current : document.body,
-      )
-    : null;
+      )}
+    </>
+  ) : null;
 }
 
 Modal.Body = ModalBody;


### PR DESCRIPTION
# 概要

モーダル表示時にバックグラウンドのスクロールを防止する機能を実装しました。

## 変更内容

### 追加されたファイル

- `packages/component-ui/src/modal/body-scroll-lock.tsx` - スクロールロック機能のコンポーネント

### 変更されたファイル

- `packages/component-ui/src/modal/modal.tsx` - BodyScrollLockコンポーネントの統合
- `packages/component-ui/src/modal/modal.stories.tsx` - ストーリーの追加とテスト用の改良
- `packages/component-ui/src/modal/Docs.mdx` - ドキュメント内のストーリー参照の更新

## 実装内容

### BodyScrollLockコンポーネント

- モーダル表示時に`body`要素にスクロールロックを適用
- `position: fixed`アプローチを使用してスクロールを防止
- スクロール位置（縦横両方）を保存し、モーダル閉じる際に復元
- スクロールバーの幅を検出し、レイアウトシフトを防止するためのpadding調整
- グローバルCSSに依存せず、すべてインラインスタイルで実装
- DOM要素をレンダリングせず、副作用のみを提供

### 特徴

- **レイアウトシフト防止**: スクロールバーの有無を検出し、その幅分を考慮
- **スクロール位置保持**: 縦横両方のスクロール位置を正確に復元
- **最小限の変更**: 必要なスタイルプロパティのみを変更
- **安全な復元**: 元のインラインスタイル値を保存し、適切にクリーンアップ

## テスト

### Storybookでの確認

- `Component`ストーリー: 基本的な動作確認用
- `Base`ストーリー: スクロール可能なページでの動作確認用（40行のbrタグを追加）

### 動作確認ポイント

1. モーダル表示時にバックグラウンドのスクロールが無効化される
2. モーダル閉じる際にスクロール位置が正確に復元される
3. スクロールバーの有無によるレイアウトシフトが発生しない
4. 既存のスタイルが適切に復元される

## Breaking Changes

なし

## その他

- 既存のModalコンポーネントの動作に影響を与えることなく機能が追加されています
- グローバルCSS不要で、完全に自己完結した実装です
