### PR TITLE
feat: Add Snackbar component for Toast migration phase 1

### DIFF
--- a/packages/component-config/src/tailwind-config.ts
+++ b/packages/component-config/src/tailwind-config.ts
@@ -124,6 +124,26 @@ export const tailwindConfig = {
             transform: 'translate3d(-50%, 0, 0)',
           },
         },
+        'snackbar-in': {
+          from: {
+            opacity: 0,
+            transform: 'translate3d(-10%, 0, 0)',
+          },
+          to: {
+            opacity: 1,
+            transform: 'translate3d(0, 0, 0)',
+          },
+        },
+        'snackbar-out': {
+          from: {
+            opacity: 1,
+            transform: 'translate3d(0, 0, 0)',
+          },
+          to: {
+            opacity: 0,
+            transform: 'translate3d(-50%, 0, 0)',
+          },
+        },
       },
       animation: {
         'circular-small-move': 'circular-small-move 1.4s ease-in-out infinite',
@@ -131,6 +151,8 @@ export const tailwindConfig = {
         'circular-large-move': 'circular-large-move 1.4s ease-in-out infinite',
         'toast-in': 'toast-in 0.25s cubic-bezier(.11, .57, .14, 1)',
         'toast-out': 'toast-out 0.25s cubic-bezier(0, .14, .75, 1)',
+        'snackbar-in': 'snackbar-in 0.25s cubic-bezier(.11, .57, .14, 1)',
+        'snackbar-out': 'snackbar-out 0.25s cubic-bezier(0, .14, .75, 1)',
       },
       zIndex: {
         hide: -1,
@@ -144,6 +166,7 @@ export const tailwindConfig = {
         modal: 1100,
         preloader: 1200,
         toast: 1300,
+        snackbar: 1300,
         tooltip: 1400,
       },
     },

--- a/packages/component-ui/src/index.ts
+++ b/packages/component-ui/src/index.ts
@@ -17,6 +17,7 @@ export * from './radio';
 export * from './search';
 export * from './select';
 export * from './select-sort';
+export * from './snackbar';
 export * from './tab';
 export * from './table';
 export * from './tag';

--- a/packages/component-ui/src/snackbar/Docs.mdx
+++ b/packages/component-ui/src/snackbar/Docs.mdx
@@ -1,0 +1,12 @@
+import { Canvas, Meta, ArgTypes, Story, Controls, Source } from '@storybook/blocks';
+import SnackbarStories, { Component, Base } from './snackbar.stories';
+
+<Meta title="Snackbar" of={SnackbarStories} />
+
+# Snackbar
+
+<Canvas>
+  <Story of={Component} />
+</Canvas>
+
+<Controls of={Component} />

--- a/packages/component-ui/src/snackbar/index.ts
+++ b/packages/component-ui/src/snackbar/index.ts
@@ -1,0 +1,2 @@
+export * from './snackbar';
+export * from './snackbar-provider';

--- a/packages/component-ui/src/snackbar/snackbar-provider.tsx
+++ b/packages/component-ui/src/snackbar/snackbar-provider.tsx
@@ -1,0 +1,60 @@
+import type { PropsWithChildren } from 'react';
+import { createContext, useCallback, useContext, useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+import { Snackbar } from './snackbar';
+import type { SnackbarState } from './type';
+
+type AddSnackbarArgs = { message: string; state: SnackbarState };
+
+type SnackbarProviderProps = {
+  addSnackbar: (args: AddSnackbarArgs) => void;
+  removeSnackbar: (id: number) => void;
+};
+
+const SnackbarContext = createContext<SnackbarProviderProps>({} as SnackbarProviderProps);
+
+export const SnackbarProvider = ({ children }: PropsWithChildren) => {
+  const [isClientRender, setIsClientRender] = useState(false);
+  const [snackbars, setSnackbars] = useState<{ id: number; message: string; state: SnackbarState }[]>([]);
+
+  const addSnackbar = useCallback(({ message, state }: AddSnackbarArgs) => {
+    setSnackbars((prev) => [...prev, { id: Math.trunc(Math.random() * 100000), message, state }]);
+  }, []);
+
+  const removeSnackbar = useCallback((id: number) => {
+    setSnackbars((prev) => prev.filter((snackbar) => snackbar.id !== id));
+  }, []);
+
+  useEffect(() => {
+    setIsClientRender(true);
+  }, []);
+
+  return (
+    <SnackbarContext.Provider value={{ addSnackbar, removeSnackbar }}>
+      {children}
+      {isClientRender &&
+        createPortal(
+          <div className="z-snackbar pointer-events-none fixed bottom-0 left-0 mb-4 ml-4 flex w-full flex-col-reverse gap-[16px]">
+            {snackbars.map(({ id, message, state }) => (
+              <Snackbar
+                key={id}
+                state={state}
+                isAutoClose
+                isAnimation
+                onClickClose={() => removeSnackbar(id)}
+                width={475}
+              >
+                {message}
+              </Snackbar>
+            ))}
+          </div>,
+          document.body,
+        )}
+    </SnackbarContext.Provider>
+  );
+};
+
+export const useSnackbar = () => {
+  return useContext(SnackbarContext);
+};

--- a/packages/component-ui/src/snackbar/snackbar.stories.tsx
+++ b/packages/component-ui/src/snackbar/snackbar.stories.tsx
@@ -1,0 +1,108 @@
+import { action } from '@storybook/addon-actions';
+import type { Meta, StoryObj } from '@storybook/react';
+import type { ChangeEvent } from 'react';
+import { useCallback, useState } from 'react';
+
+import { Button } from '../button';
+import { TextInput } from '../text-input';
+import { Snackbar, SnackbarProvider, useSnackbar } from '.';
+
+const meta: Meta<typeof Snackbar> = {
+  title: 'Components/Snackbar',
+  decorators: [
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (Story: any) => (
+      <SnackbarProvider>
+        <Story />
+      </SnackbarProvider>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Snackbar>;
+
+export const Component: Story = {
+  args: {
+    state: 'success',
+  },
+  argTypes: {
+    state: {
+      options: ['success', 'error', 'warning', 'information'],
+      control: { type: 'radio' },
+    },
+  },
+  parameters: {
+    chromatic: { disable: true },
+  },
+  render: function MyFunc({ ...args }) {
+    const [value, setValue] = useState<string>('');
+    const { addSnackbar } = useSnackbar();
+    const handleClick = useCallback(() => {
+      if (args.state) addSnackbar({ state: args.state, message: value });
+    }, [addSnackbar, args.state, value]);
+
+    return (
+      <div className="flex flex-col justify-start gap-2">
+        <div>
+          <TextInput
+            {...args}
+            value={value}
+            placeholder="テキストを入力"
+            onChange={(e: ChangeEvent<HTMLInputElement>) => {
+              setValue(e.target.value);
+            }}
+            onClickClearButton={() => {
+              setValue('');
+            }}
+          />
+        </div>
+        <div>
+          <Button onClick={handleClick}>スナックバーを表示</Button>
+        </div>
+      </div>
+    );
+  },
+};
+
+export function Base() {
+  const { addSnackbar } = useSnackbar();
+
+  const handleClick = useCallback(() => {
+    addSnackbar({ message: 'テキスト', state: 'information' });
+  }, [addSnackbar]);
+
+  return (
+    <>
+      <div className="mb-10">
+        <Button onClick={handleClick}>スナックバーを表示</Button>
+      </div>
+      <div className="flex flex-col gap-2">
+        <Snackbar state="success" onClickClose={action('閉じる')} width="475px">
+          テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト
+        </Snackbar>
+        <Snackbar state="error" onClickClose={action('閉じる')} width="475px">
+          テキスト
+        </Snackbar>
+        <Snackbar state="warning" onClickClose={action('閉じる')} width="475px">
+          テキスト
+        </Snackbar>
+        <Snackbar state="information" onClickClose={action('閉じる')}>
+          テキスト
+        </Snackbar>
+        <Snackbar state="success" onClickClose={action('閉じる')}>
+          テキスト
+        </Snackbar>
+        <Snackbar state="error" onClickClose={action('閉じる')}>
+          テキスト
+        </Snackbar>
+        <Snackbar state="warning" onClickClose={action('閉じる')}>
+          テキスト
+        </Snackbar>
+        <Snackbar state="information" onClickClose={action('閉じる')}>
+          テキスト
+        </Snackbar>
+      </div>
+    </>
+  );
+}

--- a/packages/component-ui/src/snackbar/snackbar.tsx
+++ b/packages/component-ui/src/snackbar/snackbar.tsx
@@ -1,0 +1,82 @@
+import clsx from 'clsx';
+import type { AnimationEvent, CSSProperties, ReactNode } from 'react';
+import { useCallback, useEffect, useState } from 'react';
+
+import { Icon } from '../icon';
+import { IconButton } from '../icon-button';
+import type { SnackbarState } from './type';
+
+const CLOSE_TIME_MSEC = 5000;
+
+type Props = {
+  state?: SnackbarState;
+  width?: CSSProperties['width'];
+  isAutoClose?: boolean;
+  isAnimation?: boolean;
+  children?: ReactNode;
+  onClickClose: () => void;
+};
+
+export function Snackbar({
+  state = 'information',
+  width = 'auto',
+  isAutoClose = false,
+  isAnimation = false,
+  children,
+  onClickClose,
+}: Props) {
+  const [isRemoving, setIsRemoving] = useState(false);
+
+  const handleClose = useCallback(() => {
+    if (isAnimation) {
+      setIsRemoving(true);
+    } else {
+      onClickClose();
+    }
+  }, [isAnimation, onClickClose]);
+
+  const handleAnimationEnd = (e: AnimationEvent<HTMLDivElement>) =>
+    window.getComputedStyle(e.currentTarget).opacity === '0' && onClickClose();
+
+  const wrapperClasses = clsx('pointer-events-auto flex items-start gap-1 bg-white p-4 shadow-floatingShadow', {
+    ['animate-snackbar-in']: isAnimation && !isRemoving,
+    ['animate-snackbar-out opacity-0']: isAnimation && isRemoving,
+  });
+  const iconClasses = clsx('flex items-center', {
+    'fill-supportSuccess': state === 'success',
+    'fill-supportError': state === 'error',
+    'fill-supportWarning': state === 'warning',
+    'fill-supportInfo': state === 'information',
+  });
+  const textClasses = clsx('typography-body13regular flex-1 pt-[3px]', {
+    'text-supportError': state === 'error',
+    'text-text01': state === 'success' || state === 'warning' || state === 'information',
+  });
+
+  const iconName = {
+    success: 'success-filled',
+    error: 'attention',
+    warning: 'warning',
+    information: 'information-filled',
+  } as const;
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      if (isAutoClose) {
+        setIsRemoving(true);
+      }
+    }, CLOSE_TIME_MSEC);
+
+    return () => window.clearTimeout(timer);
+  }, [isAutoClose]);
+
+  return (
+    <div className={wrapperClasses} style={{ width }} onAnimationEnd={handleAnimationEnd}>
+      <div className={iconClasses}>
+        <Icon name={iconName[state]} />
+      </div>
+      <p className={textClasses}>{children}</p>
+      <IconButton icon="close" size="medium" variant="text" onClick={handleClose} isNoPadding />
+    </div>
+  );
+}

--- a/packages/component-ui/src/snackbar/type.ts
+++ b/packages/component-ui/src/snackbar/type.ts
@@ -1,0 +1,1 @@
+export type SnackbarState = 'success' | 'error' | 'warning' | 'information';

--- a/packages/component-ui/src/toast/toast-provider.tsx
+++ b/packages/component-ui/src/toast/toast-provider.tsx
@@ -14,6 +14,10 @@ type ToastProviderProps = {
 
 const ToastContext = createContext<ToastProviderProps>({} as ToastProviderProps);
 
+/**
+ * @deprecated ToastProvider は非推奨です。代わりに SnackbarProvider を使用してください。
+ * ToastProvider is deprecated. Use SnackbarProvider instead.
+ */
 export const ToastProvider = ({ children }: PropsWithChildren) => {
   const [isClientRender, setIsClientRender] = useState(false);
   const [toasts, setToasts] = useState<{ id: number; message: string; state: ToastState }[]>([]);
@@ -48,6 +52,10 @@ export const ToastProvider = ({ children }: PropsWithChildren) => {
   );
 };
 
+/**
+ * @deprecated useToast は非推奨です。代わりに useSnackbar を使用してください。
+ * useToast is deprecated. Use useSnackbar instead.
+ */
 export const useToast = () => {
   return useContext(ToastContext);
 };

--- a/packages/component-ui/src/toast/toast.tsx
+++ b/packages/component-ui/src/toast/toast.tsx
@@ -17,6 +17,10 @@ type Props = {
   onClickClose: () => void;
 };
 
+/**
+ * @deprecated Toast コンポーネントは非推奨です。代わりに Snackbar を使用してください。
+ * Toast component is deprecated. Use Snackbar instead.
+ */
 export function Toast({
   state = 'information',
   width = 'auto',

--- a/packages/component-ui/src/toast/type.ts
+++ b/packages/component-ui/src/toast/type.ts
@@ -1,1 +1,2 @@
+/** @deprecated Use SnackbarState instead */
 export type ToastState = 'success' | 'error' | 'warning' | 'information';


### PR DESCRIPTION
# Toast → Snackbar 移行計画 フェーズ1: Snackbarコンポーネント追加

## 概要

Toast コンポーネントを Snackbar に名称変更するための移行計画のフェーズ1を実装しました。
既存の Toast コンポーネントとの併存状態を保ちつつ、新しい Snackbar コンポーネントを追加し、段階的移行の準備を整えます。

## 変更内容

### ✅ 新しいSnackbarコンポーネントの追加

新しく `packages/component-ui/src/snackbar/` ディレクトリを作成し、以下のファイルを実装：

- `snackbar.tsx` - メインコンポーネント（Toast と同じAPI）
- `snackbar-provider.tsx` - Context プロバイダー（ToastProvider と同じAPI）
- `type.ts` - TypeScript型定義（`SnackbarState`）
- `index.ts` - エクスポートファイル
- `snackbar.stories.tsx` - Storybook ストーリー
- `Docs.mdx` - ドキュメント

### ✅ CSS設定の追加

`packages/component-config/src/tailwind-config.ts` に以下を追加：

- `snackbar-in` / `snackbar-out` キーフレームアニメーション
- `animate-snackbar-in` / `animate-snackbar-out` アニメーション設定
- `z-snackbar: 1300` z-index設定（Toast と同じ値）

### ✅ コンポーネントエクスポートの追加

`packages/component-ui/src/index.ts` に `export * from './snackbar';` を追加

### ✅ Deprecation マークの追加

既存の Toast 関連コンポーネントに `@deprecated` マークを追加：

- `Toast` コンポーネント
- `ToastProvider`
- `useToast` フック
- `ToastState` 型

## 技術仕様

### API互換性

新しい Snackbar コンポーネントは既存の Toast と完全に同じAPIを提供：

```typescript
// Before (Toast)
import { Toast, ToastProvider, useToast } from '@zenkigen-inc/component-ui';

// After (Snackbar) - 同じAPI
import { Snackbar, SnackbarProvider, useSnackbar } from '@zenkigen-inc/component-ui';
```

### Breaking Change なし

- 既存の Toast コンポーネントは完全に動作継続
- 利用者のコードに影響なし
- 段階的移行が可能

## テスト結果

- ✅ ビルド成功 (`yarn build:all`)
- ✅ 型チェック成功 (`yarn type-check`)
- ✅ Lint成功 (`yarn lint:fix`)

## 次のステップ（フェーズ2）

1. CHANGELOGの更新（v2.1.0リリース）
2. 移行ガイドの作成
3. ドキュメント更新
4. 利用者への移行案内（3-6ヶ月の移行期間）

## 影響範囲

- **利用者への影響**: なし（既存コード動作継続）
- **Breaking Change**: なし
- **新機能**: Snackbar コンポーネント追加
