### PR TITLE
Test｜135｜Investigate className override issue in UI components

### DIFF
--- a/packages/component-ui/src/button/button.stories.tsx
+++ b/packages/component-ui/src/button/button.stories.tsx
@@ -51,7 +51,9 @@ export function Base() {
   return (
     <div>
       <div className="mt-2 flex items-center gap-2">
-        <Button size="small">ボタンラベル</Button>
+        <Button size="small" className="border-2 border-black bg-yellow-500">
+          ボタンラベル
+        </Button>
         <Button size="small" before={<Icon name="add" size="small" />}>
           ボタンラベル
         </Button>

--- a/packages/component-ui/src/icon/icon.stories.tsx
+++ b/packages/component-ui/src/icon/icon.stories.tsx
@@ -33,7 +33,7 @@ type Props = {
 function IconList(props: Props) {
   return (
     <div className={props.className}>
-      <Icon name="add" color={props.color} />
+      <Icon name="add" color={props.color} className="border-2 border-black bg-yellow-500" />
       <Icon name="ai" color={props.color} />
       <Icon name="angle-down" color={props.color} />
       <Icon name="angle-left" color={props.color} />

--- a/packages/component-ui/src/text-area/text-area.stories.tsx
+++ b/packages/component-ui/src/text-area/text-area.stories.tsx
@@ -69,6 +69,7 @@ export const Base: Story = {
                 action('onChange')(e);
                 setValue(e.target.value);
               }}
+              className="border-2 border-black bg-yellow-500"
             />
             <ErrorText></ErrorText>
           </div>

--- a/packages/component-ui/src/text-input/text-input.stories.tsx
+++ b/packages/component-ui/src/text-input/text-input.stories.tsx
@@ -43,6 +43,7 @@ export const Component: Story = {
             onClickClearButton={() => {
               setValue('');
             }}
+            className="border-2 border-black bg-yellow-500"
           />
         </div>
       </div>


### PR DESCRIPTION
# 概要

コンポーネントにclassNameが設定できてしまう問題を確認するためのPRです。

複数のコンポーネント（Button、Icon、TextArea、TextInput）において、親コンポーネントから `className` プロパティを渡すことで、デザインシステムで定義されたスタイルを上書きできてしまうことを実証しています。

## 問題の詳細

現在のコンポーネント実装では、以下の問題があります：

1. **デザインシステムの統一性の破綻**: コンポーネントに任意のclassNameを指定できるため、デザインシステムで定義されたスタイルガイドラインを無視したカスタマイズが可能
2. **予期しないスタイル変更**: 開発者が意図せず重要なスタイルを上書きしてしまうリスク
3. **メンテナンス性の低下**: コンポーネントの外見が予測できないため、デバッグや保守が困難

## 実証内容

以下のコンポーネントのStorybookで、`className="border-2 border-black bg-yellow-500"` を追加して問題を可視化：

- **Button**: `button.stories.tsx`
- **Icon**: `icon.stories.tsx`
- **TextArea**: `text-area.stories.tsx`
- **TextInput**: `text-input.stories.tsx`

## 期待される改善案

1. **className プロパティの制限**: コンポーネントのインターフェースから `className` を除外
2. **デザインバリエーションの明確化**: 必要なバリエーションはpropsとして明示的に提供
3. **スタイル拡張の仕組み**: 本当に必要な場合のみ、制御された方法でのスタイル拡張を可能にする

## 影響範囲

- Storybookでの表示確認のみ
- 実際のコンポーネントAPIには変更なし
- 既存の実装に対する破壊的変更なし

## 確認方法

Storybookを起動して、該当コンポーネントのストーリーで黄色の背景色と黒い境界線が適用されていることを確認してください。

```bash
yarn storybook
```

## 今後の対応

このPRは問題の確認・実証が目的のため、実際の修正は別のPRで対応予定です。
