### PR TITLE
fix: add missing React import to resolve 'React is not defined' error in icon components

### DIFF
--- a/packages/component-icons/codegen.cjs
+++ b/packages/component-icons/codegen.cjs
@@ -43,7 +43,7 @@ function generateIconFile(key, value) {
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const ${componentName}: React.ReactElement = (
   ${value}

--- a/packages/component-icons/src/icons/add.tsx
+++ b/packages/component-icons/src/icons/add.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const addIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="add">

--- a/packages/component-icons/src/icons/ai.tsx
+++ b/packages/component-icons/src/icons/ai.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const aiIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="ai">

--- a/packages/component-icons/src/icons/angle-down.tsx
+++ b/packages/component-icons/src/icons/angle-down.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const angledownIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="angleDown">

--- a/packages/component-icons/src/icons/angle-left.tsx
+++ b/packages/component-icons/src/icons/angle-left.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const angleleftIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="angleLeft">

--- a/packages/component-icons/src/icons/angle-right.tsx
+++ b/packages/component-icons/src/icons/angle-right.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const anglerightIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="angleRight">

--- a/packages/component-icons/src/icons/angle-small-down.tsx
+++ b/packages/component-icons/src/icons/angle-small-down.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const anglesmalldownIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="angleSmallDown">

--- a/packages/component-icons/src/icons/angle-small-up.tsx
+++ b/packages/component-icons/src/icons/angle-small-up.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const anglesmallupIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="angleSmallUp">

--- a/packages/component-icons/src/icons/angle-up.tsx
+++ b/packages/component-icons/src/icons/angle-up.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const angleupIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="angleUp">

--- a/packages/component-icons/src/icons/arrow-down.tsx
+++ b/packages/component-icons/src/icons/arrow-down.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const arrowdownIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="arrowDown">

--- a/packages/component-icons/src/icons/arrow-left.tsx
+++ b/packages/component-icons/src/icons/arrow-left.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const arrowleftIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="arrowLeft">

--- a/packages/component-icons/src/icons/arrow-right.tsx
+++ b/packages/component-icons/src/icons/arrow-right.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const arrowrightIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="arrowRight">

--- a/packages/component-icons/src/icons/arrow-up.tsx
+++ b/packages/component-icons/src/icons/arrow-up.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const arrowupIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="arrowUp">

--- a/packages/component-icons/src/icons/attachment.tsx
+++ b/packages/component-icons/src/icons/attachment.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const attachmentIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="attachment">

--- a/packages/component-icons/src/icons/attention.tsx
+++ b/packages/component-icons/src/icons/attention.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const attentionIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="attention">

--- a/packages/component-icons/src/icons/building.tsx
+++ b/packages/component-icons/src/icons/building.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const buildingIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="building">

--- a/packages/component-icons/src/icons/calendar-check.tsx
+++ b/packages/component-icons/src/icons/calendar-check.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const calendarcheckIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="calendarCheck">

--- a/packages/component-icons/src/icons/calendar-draft.tsx
+++ b/packages/component-icons/src/icons/calendar-draft.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const calendardraftIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="calendarDraft">

--- a/packages/component-icons/src/icons/calendar-minus.tsx
+++ b/packages/component-icons/src/icons/calendar-minus.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const calendarminusIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="calendarMinus">

--- a/packages/component-icons/src/icons/calendar-today.tsx
+++ b/packages/component-icons/src/icons/calendar-today.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const calendartodayIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="calendarToday">

--- a/packages/component-icons/src/icons/calendar.tsx
+++ b/packages/component-icons/src/icons/calendar.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const calendarIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="calendar">

--- a/packages/component-icons/src/icons/caret-down.tsx
+++ b/packages/component-icons/src/icons/caret-down.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const caretdownIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="caretDown">

--- a/packages/component-icons/src/icons/caret-right.tsx
+++ b/packages/component-icons/src/icons/caret-right.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const caretrightIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="caretRight">

--- a/packages/component-icons/src/icons/chart-bar.tsx
+++ b/packages/component-icons/src/icons/chart-bar.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const chartbarIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="chartBar">

--- a/packages/component-icons/src/icons/chart-line.tsx
+++ b/packages/component-icons/src/icons/chart-line.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const chartlineIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="chartLine">

--- a/packages/component-icons/src/icons/check.tsx
+++ b/packages/component-icons/src/icons/check.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const checkIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="check">

--- a/packages/component-icons/src/icons/circle.tsx
+++ b/packages/component-icons/src/icons/circle.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const circleIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="circle">

--- a/packages/component-icons/src/icons/close.tsx
+++ b/packages/component-icons/src/icons/close.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const closeIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="close">

--- a/packages/component-icons/src/icons/comment.tsx
+++ b/packages/component-icons/src/icons/comment.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const commentIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="comment">

--- a/packages/component-icons/src/icons/contract.tsx
+++ b/packages/component-icons/src/icons/contract.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const contractIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="contract">

--- a/packages/component-icons/src/icons/copy.tsx
+++ b/packages/component-icons/src/icons/copy.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const copyIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="copy">

--- a/packages/component-icons/src/icons/delete.tsx
+++ b/packages/component-icons/src/icons/delete.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const deleteIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="delete">

--- a/packages/component-icons/src/icons/document.tsx
+++ b/packages/component-icons/src/icons/document.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const documentIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="document">

--- a/packages/component-icons/src/icons/documents.tsx
+++ b/packages/component-icons/src/icons/documents.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const documentsIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="documents">

--- a/packages/component-icons/src/icons/double circle.tsx
+++ b/packages/component-icons/src/icons/double circle.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const doublecircleIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="double circle">

--- a/packages/component-icons/src/icons/download-document.tsx
+++ b/packages/component-icons/src/icons/download-document.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const downloaddocumentIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="downloadDocument">

--- a/packages/component-icons/src/icons/download.tsx
+++ b/packages/component-icons/src/icons/download.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const downloadIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="download">

--- a/packages/component-icons/src/icons/edit.tsx
+++ b/packages/component-icons/src/icons/edit.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const editIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="edit">

--- a/packages/component-icons/src/icons/email.tsx
+++ b/packages/component-icons/src/icons/email.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const emailIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="email">

--- a/packages/component-icons/src/icons/expand.tsx
+++ b/packages/component-icons/src/icons/expand.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const expandIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="expand">

--- a/packages/component-icons/src/icons/external-link.tsx
+++ b/packages/component-icons/src/icons/external-link.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const externallinkIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="externalLink">

--- a/packages/component-icons/src/icons/filter.tsx
+++ b/packages/component-icons/src/icons/filter.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const filterIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="filter">

--- a/packages/component-icons/src/icons/flag.tsx
+++ b/packages/component-icons/src/icons/flag.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const flagIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="flag">

--- a/packages/component-icons/src/icons/global.tsx
+++ b/packages/component-icons/src/icons/global.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const globalIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="global">

--- a/packages/component-icons/src/icons/graph-line.tsx
+++ b/packages/component-icons/src/icons/graph-line.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const graphlineIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="graphLine">

--- a/packages/component-icons/src/icons/hamburger-close.tsx
+++ b/packages/component-icons/src/icons/hamburger-close.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const hamburgercloseIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="hamburgerClose">

--- a/packages/component-icons/src/icons/hamburger.tsx
+++ b/packages/component-icons/src/icons/hamburger.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const hamburgerIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="hamburger">

--- a/packages/component-icons/src/icons/help.tsx
+++ b/packages/component-icons/src/icons/help.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const helpIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="help">

--- a/packages/component-icons/src/icons/hint.tsx
+++ b/packages/component-icons/src/icons/hint.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const hintIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="hint">

--- a/packages/component-icons/src/icons/home.tsx
+++ b/packages/component-icons/src/icons/home.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const homeIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="home">

--- a/packages/component-icons/src/icons/image.tsx
+++ b/packages/component-icons/src/icons/image.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const imageIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="image">

--- a/packages/component-icons/src/icons/information-filled.tsx
+++ b/packages/component-icons/src/icons/information-filled.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const informationfilledIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="informationFilled">

--- a/packages/component-icons/src/icons/information.tsx
+++ b/packages/component-icons/src/icons/information.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const informationIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="information">

--- a/packages/component-icons/src/icons/input-delete.tsx
+++ b/packages/component-icons/src/icons/input-delete.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const inputdeleteIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="inputDelete">

--- a/packages/component-icons/src/icons/link.tsx
+++ b/packages/component-icons/src/icons/link.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const linkIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="link">

--- a/packages/component-icons/src/icons/list.tsx
+++ b/packages/component-icons/src/icons/list.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const listIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="list">

--- a/packages/component-icons/src/icons/logout.tsx
+++ b/packages/component-icons/src/icons/logout.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const logoutIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="logout">

--- a/packages/component-icons/src/icons/message-text.tsx
+++ b/packages/component-icons/src/icons/message-text.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const messagetextIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="messageText">

--- a/packages/component-icons/src/icons/more.tsx
+++ b/packages/component-icons/src/icons/more.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const moreIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="more">

--- a/packages/component-icons/src/icons/movie.tsx
+++ b/packages/component-icons/src/icons/movie.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const movieIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="movie">

--- a/packages/component-icons/src/icons/notification.tsx
+++ b/packages/component-icons/src/icons/notification.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const notificationIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="notification">

--- a/packages/component-icons/src/icons/pause.tsx
+++ b/packages/component-icons/src/icons/pause.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const pauseIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="pause">

--- a/packages/component-icons/src/icons/pdf.tsx
+++ b/packages/component-icons/src/icons/pdf.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const pdfIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="pdf">

--- a/packages/component-icons/src/icons/picture-in-picture.tsx
+++ b/packages/component-icons/src/icons/picture-in-picture.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const pictureinpictureIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="pictureInPicture">

--- a/packages/component-icons/src/icons/play-filled.tsx
+++ b/packages/component-icons/src/icons/play-filled.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const playfilledIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="playFilled">

--- a/packages/component-icons/src/icons/play.tsx
+++ b/packages/component-icons/src/icons/play.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const playIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="play">

--- a/packages/component-icons/src/icons/presentation.tsx
+++ b/packages/component-icons/src/icons/presentation.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const presentationIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="presentation">

--- a/packages/component-icons/src/icons/remove.tsx
+++ b/packages/component-icons/src/icons/remove.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const removeIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="remove">

--- a/packages/component-icons/src/icons/score.tsx
+++ b/packages/component-icons/src/icons/score.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const scoreIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="score">

--- a/packages/component-icons/src/icons/search.tsx
+++ b/packages/component-icons/src/icons/search.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const searchIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="search">

--- a/packages/component-icons/src/icons/send.tsx
+++ b/packages/component-icons/src/icons/send.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const sendIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="send">

--- a/packages/component-icons/src/icons/share.tsx
+++ b/packages/component-icons/src/icons/share.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const shareIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="share">

--- a/packages/component-icons/src/icons/shuffle.tsx
+++ b/packages/component-icons/src/icons/shuffle.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const shuffleIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="shuffle">

--- a/packages/component-icons/src/icons/sidebar.tsx
+++ b/packages/component-icons/src/icons/sidebar.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const sidebarIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="sidebar">

--- a/packages/component-icons/src/icons/slider-editing.tsx
+++ b/packages/component-icons/src/icons/slider-editing.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const slidereditingIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="sliderEditing">

--- a/packages/component-icons/src/icons/sort-down.tsx
+++ b/packages/component-icons/src/icons/sort-down.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const sortdownIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="sortDown">

--- a/packages/component-icons/src/icons/sort-up.tsx
+++ b/packages/component-icons/src/icons/sort-up.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const sortupIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="sortUp">

--- a/packages/component-icons/src/icons/sort.tsx
+++ b/packages/component-icons/src/icons/sort.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const sortIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="sort">

--- a/packages/component-icons/src/icons/sparkle.tsx
+++ b/packages/component-icons/src/icons/sparkle.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const sparkleIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="sparkle">

--- a/packages/component-icons/src/icons/star-filled.tsx
+++ b/packages/component-icons/src/icons/star-filled.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const starfilledIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="starFilled">

--- a/packages/component-icons/src/icons/star.tsx
+++ b/packages/component-icons/src/icons/star.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const starIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="star">

--- a/packages/component-icons/src/icons/store.tsx
+++ b/packages/component-icons/src/icons/store.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const storeIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="store">

--- a/packages/component-icons/src/icons/success-filled.tsx
+++ b/packages/component-icons/src/icons/success-filled.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const successfilledIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="successFilled">

--- a/packages/component-icons/src/icons/table-download.tsx
+++ b/packages/component-icons/src/icons/table-download.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const tabledownloadIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="tableDownload">

--- a/packages/component-icons/src/icons/table-upload.tsx
+++ b/packages/component-icons/src/icons/table-upload.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const tableuploadIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="tableUpload">

--- a/packages/component-icons/src/icons/table.tsx
+++ b/packages/component-icons/src/icons/table.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const tableIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="table">

--- a/packages/component-icons/src/icons/timer.tsx
+++ b/packages/component-icons/src/icons/timer.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const timerIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="timer">

--- a/packages/component-icons/src/icons/transcription.tsx
+++ b/packages/component-icons/src/icons/transcription.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const transcriptionIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="transcription">

--- a/packages/component-icons/src/icons/triangle.tsx
+++ b/packages/component-icons/src/icons/triangle.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const triangleIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="triangle">

--- a/packages/component-icons/src/icons/upload.tsx
+++ b/packages/component-icons/src/icons/upload.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const uploadIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="upload">

--- a/packages/component-icons/src/icons/user-add.tsx
+++ b/packages/component-icons/src/icons/user-add.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const useraddIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="userAdd">

--- a/packages/component-icons/src/icons/user-group.tsx
+++ b/packages/component-icons/src/icons/user-group.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const usergroupIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="userGroup">

--- a/packages/component-icons/src/icons/user-line.tsx
+++ b/packages/component-icons/src/icons/user-line.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const userlineIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="userLine">

--- a/packages/component-icons/src/icons/user-multi.tsx
+++ b/packages/component-icons/src/icons/user-multi.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const usermultiIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="userMulti">

--- a/packages/component-icons/src/icons/user-one.tsx
+++ b/packages/component-icons/src/icons/user-one.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const useroneIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="userOne">

--- a/packages/component-icons/src/icons/user-photograph.tsx
+++ b/packages/component-icons/src/icons/user-photograph.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const userphotographIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="userPhotograph">

--- a/packages/component-icons/src/icons/user-remove.tsx
+++ b/packages/component-icons/src/icons/user-remove.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const userremoveIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="userRemove">

--- a/packages/component-icons/src/icons/user.tsx
+++ b/packages/component-icons/src/icons/user.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const userIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="user">

--- a/packages/component-icons/src/icons/video.tsx
+++ b/packages/component-icons/src/icons/video.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const videoIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="video">

--- a/packages/component-icons/src/icons/volume-off.tsx
+++ b/packages/component-icons/src/icons/volume-off.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const volumeoffIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="volumeOff">

--- a/packages/component-icons/src/icons/volume.tsx
+++ b/packages/component-icons/src/icons/volume.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const volumeIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="volume">

--- a/packages/component-icons/src/icons/warning.tsx
+++ b/packages/component-icons/src/icons/warning.tsx
@@ -2,7 +2,7 @@
 * NOTE: This file is auto generated
 * Do not edit manually.
 */
-import type React from 'react';
+import React from 'react';
 
 export const warningIcon: React.ReactElement = (
   <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="warning">


### PR DESCRIPTION
# fix: add missing React import to resolve "React is not defined" error in icon components

## 概要

iconコンポーネント群で発生していた "React is not defined" エラーの修正です。

## 変更内容

- 各iconコンポーネントファイルに `import React from 'react';` を追加
- これにより、Reactが未定義でエラーとなる問題を解消

## 背景・理由

- これまで `import type React from 'react';` のみで、JSX変換時にReactが参照できずエラーとなっていました
- 明示的にReactをimportすることで、エラーが発生しなくなります

## 影響範囲

- `packages/component-icons/src/icons/` 配下の全てのiconコンポーネント
- 他のパッケージや機能への影響はありません

## 動作確認

- 各iconコンポーネントをimportしても "React is not defined" エラーが発生しないことを確認

## 備考

- これらのファイルは自動生成されているため、今後も同様のエラーが発生しないようにgenerator側も確認が必要です
