### PR TITLE
Improve Noto Sans JP web font loading configuration

### DIFF
--- a/.storybook/preview-body.html
+++ b/.storybook/preview-body.html
@@ -1,3 +1,3 @@
-<style>
-  @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;600&display=swap');
-</style>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&display=swap" rel="stylesheet" />

--- a/README.md
+++ b/README.md
@@ -40,6 +40,37 @@ module.exports = {
 };
 ```
 
+### 3. Webフォント Noto Sans JP の読み込み設定
+
+以下のコードを適切な位置に設定し、Webフォント Noto Sans JP の読み込み設定を行ってください：
+
+※ ZENKIGENのコンポーネントライブラリのインストールを行うことで component-config が提供する設定により fontFamily に Noto Sans JP が指定されます。
+
+```
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&display=swap" rel="stylesheet">
+```
+
+**Next.js の場合**
+
+```tsx src/app/layout.tsx
+...
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="ja">
+      <head>
+        ...
+        <link rel="preconnect" href="https://fonts.googleapis.com">
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+        <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&display=swap" rel="stylesheet">
+      </head>
+      ...
+    </html>
+  );
+}
+```
+
 ## 基本的な使い方
 
 ```tsx


### PR DESCRIPTION
# Webフォント Noto Sans JP の読み込み設定を改善

## 概要

WebフォントのNoto Sans JPの読み込み設定を改善し、適切な設定方法をドキュメント化しました。

## 変更内容

### 1. Storybookのフォント読み込み方法を改善

- `.storybook/preview-body.html` において、`@import` から `<link>` タグによる読み込みに変更
- `preconnect` を使用してパフォーマンスを向上
- フォントウェイトを 600 → 700 に変更

### 2. READMEにWebフォント設定手順を追加

- `README.md` に「Webフォント Noto Sans JP の読み込み設定」セクションを追加
- 基本的な設定方法とNext.jsでの設定例を記載
- component-config によるfontFamily設定についても説明

## 技術的な改善点

- `@import` による読み込みからリンクタグに変更することで、CSSの読み込みパフォーマンスが向上
- `preconnect` によりGoogle Fontsへの接続が高速化
- フォントウェイト700（bold）により、より強いフォントウェイトが利用可能

## 影響範囲

- Storybookでのフォント表示が改善
- 新規利用者がWebフォント設定を容易に行えるようになる
- 既存の利用者には影響なし（component-config の設定は変更なし）

## 動作確認

- Storybookが正常に動作することを確認
- READMEの記載内容が正確であることを確認
