### PR TITLE
Add minWidth property to Tab component and improve layout flexibility

### DIFF
--- a/packages/component-ui/src/tab/Docs.mdx
+++ b/packages/component-ui/src/tab/Docs.mdx
@@ -1,5 +1,5 @@
 import { Canvas, Meta, ArgTypes, Story, Controls, Source } from '@storybook/blocks';
-import TabStories, { Component } from './tab.stories';
+import TabStories, { Component, ComponentItem, LayoutExamples } from './tab.stories';
 
 <Meta title="Tab" of={TabStories} />
 
@@ -9,4 +9,12 @@ import TabStories, { Component } from './tab.stories';
   <Story of={Component} />
 </Canvas>
 
-<Controls of={Component} />
+## Tab.Item
+
+<Canvas of={ComponentItem} />
+
+<Controls of={ComponentItem} />
+
+## Layout examples
+
+<Canvas of={LayoutExamples} />

--- a/packages/component-ui/src/tab/tab-item.tsx
+++ b/packages/component-ui/src/tab/tab-item.tsx
@@ -1,8 +1,9 @@
 import { clsx } from 'clsx';
-import type { ReactNode } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
 
 type Props = {
   id: string;
+  minWidth?: CSSProperties['minWidth'];
   isSelected?: boolean;
   isDisabled?: boolean;
   children?: ReactNode;
@@ -11,7 +12,7 @@ type Props = {
 
 export const TabItem = ({ isSelected = false, ...props }: Props) => {
   const classes = clsx(
-    'relative z-0 flex py-2 leading-[24px] before:absolute before:inset-x-0 before:bottom-0 before:h-px hover:text-text01 disabled:pointer-events-none disabled:text-disabled01',
+    'relative z-0 flex justify-center py-2 leading-[24px] before:absolute before:inset-x-0 before:bottom-0 before:h-px hover:text-text01 disabled:pointer-events-none disabled:text-disabled01',
     {
       'typography-label14regular': !isSelected,
       'text-interactive02 hover:before:bg-uiBorder04': !isSelected,
@@ -28,6 +29,7 @@ export const TabItem = ({ isSelected = false, ...props }: Props) => {
       className={classes}
       disabled={props.isDisabled}
       onClick={() => props.onClick(props.id)}
+      style={{ minWidth: props.minWidth }}
     >
       {props.children}
     </button>

--- a/packages/component-ui/src/tab/tab.stories.tsx
+++ b/packages/component-ui/src/tab/tab.stories.tsx
@@ -12,6 +12,29 @@ export default meta;
 type Story = StoryObj<typeof Tab.Item>;
 
 export const Component: Story = {
+  parameters: {
+    chromatic: { disable: true },
+  },
+  render: function MyFunc() {
+    const [selectedTab, setSelectedTab] = useState('tab1');
+
+    return (
+      <Tab>
+        <Tab.Item id="tab1" isSelected={selectedTab === 'tab1'} onClick={setSelectedTab}>
+          タブラベル
+        </Tab.Item>
+        <Tab.Item id="tab2" isSelected={selectedTab === 'tab2'} onClick={setSelectedTab}>
+          タブラベル
+        </Tab.Item>
+        <Tab.Item id="tab3" isSelected={selectedTab === 'tab3'} onClick={setSelectedTab} isDisabled>
+          タブラベル
+        </Tab.Item>
+      </Tab>
+    );
+  },
+};
+
+export const ComponentItem: Story = {
   args: {
     children: 'タブラベル',
     id: 'tab1',
@@ -43,5 +66,79 @@ export function Base() {
         タブラベル
       </Tab.Item>
     </Tab>
+  );
+}
+
+export function LayoutExamples() {
+  const [selectedTab, setSelectedTab] = useState('tab1');
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="">
+        <Tab>
+          <Tab.Item id="tab1" isSelected={selectedTab === 'tab1'} onClick={setSelectedTab}>
+            発言別
+          </Tab.Item>
+          <Tab.Item id="tab2" isSelected={selectedTab === 'tab2'} onClick={setSelectedTab}>
+            カテゴリ別
+          </Tab.Item>
+          <Tab.Item id="tab3" isSelected={selectedTab === 'tab3'} onClick={setSelectedTab}>
+            面談担当者別
+          </Tab.Item>
+        </Tab>
+      </div>
+      <div className="flex flex-col items-start gap-4">
+        <Tab>
+          <Tab.Item id="tab1" isSelected={selectedTab === 'tab1'} onClick={setSelectedTab}>
+            発言別
+          </Tab.Item>
+          <Tab.Item id="tab2" isSelected={selectedTab === 'tab2'} onClick={setSelectedTab}>
+            カテゴリ別
+          </Tab.Item>
+          <Tab.Item id="tab3" isSelected={selectedTab === 'tab3'} onClick={setSelectedTab}>
+            面談担当者別
+          </Tab.Item>
+        </Tab>
+      </div>
+      <div className="flex flex-col items-center gap-4">
+        <Tab>
+          <Tab.Item id="tab1" isSelected={selectedTab === 'tab1'} onClick={setSelectedTab}>
+            発言別
+          </Tab.Item>
+          <Tab.Item id="tab2" isSelected={selectedTab === 'tab2'} onClick={setSelectedTab}>
+            カテゴリ別
+          </Tab.Item>
+          <Tab.Item id="tab3" isSelected={selectedTab === 'tab3'} onClick={setSelectedTab}>
+            面談担当者別
+          </Tab.Item>
+        </Tab>
+      </div>
+      <div className="flex flex-col items-end gap-4">
+        <Tab>
+          <Tab.Item id="tab1" isSelected={selectedTab === 'tab1'} onClick={setSelectedTab}>
+            発言別
+          </Tab.Item>
+          <Tab.Item id="tab2" isSelected={selectedTab === 'tab2'} onClick={setSelectedTab}>
+            カテゴリ別
+          </Tab.Item>
+          <Tab.Item id="tab3" isSelected={selectedTab === 'tab3'} onClick={setSelectedTab}>
+            面談担当者別
+          </Tab.Item>
+        </Tab>
+      </div>
+      <div className="flex flex-col items-center gap-4">
+        <Tab>
+          <Tab.Item id="tab1" isSelected={selectedTab === 'tab1'} onClick={setSelectedTab} minWidth="160px">
+            発言別
+          </Tab.Item>
+          <Tab.Item id="tab2" isSelected={selectedTab === 'tab2'} onClick={setSelectedTab} minWidth="160px">
+            カテゴリ別
+          </Tab.Item>
+          <Tab.Item id="tab3" isSelected={selectedTab === 'tab3'} onClick={setSelectedTab} minWidth="160px">
+            面談担当者別
+          </Tab.Item>
+        </Tab>
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
# 概要

TabコンポーネントにminWidthプロパティを追加し、レイアウトの改善とStorybookドキュメントの拡充を実施しました。

## 変更内容

### 1. TabItemコンポーネントの改善

- `minWidth` プロパティを追加して、タブの最小幅を制御可能に
- タブアイテムのテキスト配置を中央揃えに変更（`justify-center`クラスを追加）

### 2. Storybookドキュメントの拡充

- `Tab.Item`コンポーネント専用のドキュメントセクションを追加
- 様々なレイアウトパターンを示すサンプル例を追加
- `ComponentItem`ストーリーと`LayoutExamples`ストーリーを新規作成

### 3. レイアウト例の追加

- 異なる配置パターン（左寄せ、中央、右寄せ）でのタブ表示例
- `minWidth`プロパティを使用したタブ幅統一の実装例

## 動作確認

- [ ] タブの基本機能が正常に動作することを確認
- [ ] `minWidth`プロパティが適切に適用されることを確認
- [ ] Storybookでの表示が正常であることを確認
- [ ] 既存の機能に影響がないことを確認

## その他

この変更により、より柔軟なタブレイアウトの実現が可能になり、デザインシステムとしての使いやすさが向上しました。
