### PR TITLE
fix: pagination-selectのテキストトークンをtext03からtext02に変更

### DIFF
--- a/packages/component-ui/src/pagination-select/pagination-select.tsx
+++ b/packages/component-ui/src/pagination-select/pagination-select.tsx
@@ -69,7 +69,7 @@ export function PaginationSelect({
             <Select.Option key={option.id} option={option} />
           ))}
         </Select>
-        <div className="typography-label14regular text-text03">
+        <div className="typography-label14regular text-text02">
           / {pageMax}
           {pageLabel}
         </div>


### PR DESCRIPTION
- ページネーションの「/ ページ」表示部分のテキスト色を変更
- text-text03（Tertiary text）からtext-text02（Secondary text）に変更
- より適切な視覚的階層を提供

参考: https://www.notion.so/zenkigen/Text03-256dbd50e98a80438c4ceeebf18be8e3

## 変更理由

アクセシビリティガイドライン（WCAG2.2）対応の一環でtext03 tokenを削除したく、text03をtext02に変更を行っています。
タスクページ：https://www.notion.so/zenkigen/Text03-256dbd50e98a80438c4ceeebf18be8e3

Text03トークンは「Tertiary text」として定義されており、最も低い優先度のテキストに使用されることを想定しています。しかし、pagination-selectコンポーネントの「/ ページ」表示部分は、ページネーション機能において重要な情報を提供するため、より高い視覚的優先度を持つText02（Secondary text）を使用する方が適切です。

この変更により：
- ページネーション情報の視認性が向上
- デザインシステムの意図に沿った適切なテキスト階層の実現
- ユーザビリティの向上