### PR TITLE
build: Apply token build for dark mode removal changes

### DIFF
--- a/packages/component-config/src/tokens/tokens.ts
+++ b/packages/component-config/src/tokens/tokens.ts
@@ -28,165 +28,104 @@ export const tokens = {
       "text03": "#838789",
       "textPlaceholder": "#CACCCD",
       "textOnColor": "#FFFFFF",
-      "textBlack": "#000000",
-      "text01Dark": "#FFFFFF",
-      "text02Dark": "#CACCCD",
-      "text03Dark": "#A4A5A6",
-      "textPlaceholderDark": "#838789"
+      "textBlack": "#000000"
     },
     "link": {
       "link01": "#177EE5",
-      "link01Dark": "#177EE5",
-      "link02": "#A4A5A6",
-      "link02Dark": "#A4A5A6"
+      "link02": "#A4A5A6"
     },
     "border": {
       "uiBorder01": "#DEDFE0",
-      "uiBorder01Dark": "#5C6366",
       "uiBorder02": "#CACCCD",
-      "uiBorder02Dark": "#838789",
       "uiBorder03": "#A4A5A6",
-      "uiBorder03Dark": "#838789",
       "uiBorder04": "#838789"
     },
     "background": {
       "uiBackground01": "#FFFFFF",
       "uiBackground02": "#F3F4F5",
       "uiBackground02Light": "#FAFAFA",
-      "uiBackground01Dark": "#2F3233",
-      "uiBackground02Dark": "#454A4D",
       "uiBackground02Blue": "#F1F7FD",
       "uiBackgroundBlue": "#F1F7FD",
-      "uiBackgroundBlueDark": "#115CA7",
       "uiBackgroundGray": "#F3F4F5",
-      "uiBackgroundGrayDark": "#838789",
       "uiBackgroundSuccess": "#ECFBF4",
-      "uiBackgroundSuccessDark": "#1E8353",
       "uiBackgroundError": "#FCEFF3",
-      "uiBackgroundErrorDark": "#A01D3E",
       "uiBackgroundWarning": "#FFFADC",
-      "uiBackgroundWarningDark": "#A68A00",
       "uiBackgroundTooltip": "#2F3233",
-      "uiBackgroundTooltipDark": "#F3F4F5",
       "backgroundOverlayGray": "#2f323380",
       "backgroundOverlayBlack": "#00000099"
     },
     "icon": {
       "icon01": "#6F7476",
-      "icon01Dark": "#CACCCD",
       "icon02": "#A4A5A6",
-      "icon02Dark": "#838789",
       "icon03": "#CACCCD",
-      "icon03Dark": "#5C6366",
       "iconOnColor": "#FFFFFF"
     },
     "interactive": {
       "interactive01": "#177EE5",
       "interactiveBg01": "#177EE5",
-      "interactive01Dark": "#9FCBF5",
-      "interactiveBg01Dark": "#177EE5",
       "interactive02": "#6F7476",
-      "interactive02Dark": "#CACCCD",
       "interactive03": "#177EE5",
-      "interactive03Dark": "#838789",
       "interactive04": "#CACCCD"
     },
     "field": {
       "fieldInput": "#FFFFFF",
-      "fieldInputDark": "#2F3233",
-      "fieldSearch": "#FFFFFF",
-      "fieldSearchDark": "#5C6366"
+      "fieldSearch": "#FFFFFF"
     },
     "focus": {
-      "focus": "#177EE5",
-      "focusDark": "#177EE5"
+      "focus": "#177EE5"
     },
     "hover": {
       "hover01": "#1366B9",
-      "hover01Dark": "#1366B9",
       "hover02": "#E9EAEB",
-      "hover02Dark": "#5C6366",
       "hover02Background": "#E9EAEB",
-      "hover02BackgroundDark": "#454A4D",
       "hoverUi": "#E9EAEB",
-      "hoverUiDark": "#5C6366",
       "hoverUi02": "#F3F4F5",
-      "hoverUi02Dark": "#454A4D",
       "hoverUiBorder": "#6F7476",
-      "hoverUiBorderDark": "#CACCCD",
       "hoverSelectedUi": "#CACCCD",
-      "hoverSelectedUiDark": "#838789",
       "hoverDanger": "#B22045",
-      "hoverDangerDark": "#B22045",
       "hoverError": "#B22045",
-      "hoverErrorDark": "#F9E0E6",
       "hoverInput": "#6F7476",
-      "hoverInputDark": "#A4A5A6",
       "hoverLink01": "#1366B9",
-      "hoverLink01Dark": "#9FCBF5",
       "hoverLink02": "#6F7476",
-      "hoverLink02Dark": "#DEDFE0",
       "hoverGray": "#454A4D"
     },
     "active": {
       "active01": "#0E4B87",
-      "active01Dark": "#0E4B87",
       "active02": "#CACCCD",
-      "active02Dark": "#838789",
       "active02Background": "#DEDFE0",
-      "active02BackgroundDark": "#5C6366",
       "activeUi": "#D9EAFB",
-      "activeUiDark": "#838789",
       "activeSelectedUi": "#177EE5",
-      "activeSelectedUiDark": "#177EE5",
       "activeDanger": "#821732",
-      "activeDangerDark": "#821732",
       "activeInput": "#1366B9",
-      "activeInputDark": "#CACCCD",
       "activeLink01": "#0E4B87",
-      "activeLink01Dark": "#D9EAFB",
-      "activeLink02": "#2F3233",
-      "activeLink02Dark": "#E9EAEB"
+      "activeLink02": "#2F3233"
     },
     "selected": {
       "selectedUi": "#D9EAFB",
-      "selectedUiDark": "#1366B9",
       "selectedUiGray": "#DEDFE0",
-      "selectedUiGrayDark": "#838789",
       "selectedUiOnColor": "#FFFFFF",
-      "selectedUiBorder": "#177EE5",
-      "selectedUiBorderDark": "#9FCBF5"
+      "selectedUiBorder": "#177EE5"
     },
     "disabled": {
       "disabled01": "#DEDFE0",
-      "disabled01Dark": "#5C6366",
       "disabled02": "#F3F4F5",
-      "disabled02Dark": "#838789",
       "disabled03": "#454A4D",
       "disabled04": "#0E4B87",
       "disabledLink01": "#DEDFE0",
       "disabledLink02": "#DEDFE0",
-      "disabledLink01Dark": "#115CA7",
-      "disabledLink02Dark": "#5C6366",
-      "disabledOn": "#D9EAFB",
-      "disabledOnDark": "#9FCBF5"
+      "disabledOn": "#D9EAFB"
     },
     "support": {
       "supportError": "#D92B57",
       "supportErrorLight": "#F4BFCD",
-      "supportErrorDark": "#E67490",
       "supportSuccess": "#2DC87D",
       "supportSuccessLight": "#CCF4E1",
-      "supportSuccessDark": "#69DDA5",
       "supportInfo": "#177EE5",
       "supportInfoLight": "#B9D8F7",
-      "supportInfoDark": "#177EE5",
       "supportWarning": "#FCD200",
       "supportWarningLight": "#FFF4BA",
-      "supportWarningDark": "#FFE976",
       "supportDanger": "#D92B57",
-      "supportDangerLight": "#F4BFCD",
-      "supportDangerDark": "#E67490"
+      "supportDangerLight": "#F4BFCD"
     }
   },
   "colors": {

--- a/packages/component-config/style-dictionary/transformed-tokens.json
+++ b/packages/component-config/style-dictionary/transformed-tokens.json
@@ -112,26 +112,6 @@
         "value": "#000000",
         "type": "color",
         "description": "Title text"
-      },
-      "Text01Dark": {
-        "value": "#FFFFFF",
-        "type": "color",
-        "description": "Primary text, Body copy, Headers - Dark"
-      },
-      "Text02Dark": {
-        "value": "#CACCCD",
-        "type": "color",
-        "description": "Secondary text, Input labels - Dark"
-      },
-      "Text03Dark": {
-        "value": "#A4A5A6",
-        "type": "color",
-        "description": "Tertiary text - Dark"
-      },
-      "TextPlaceholderDark": {
-        "value": "#838789",
-        "type": "color",
-        "description": "Placeholder text - Dark"
       }
     },
     "Link": {
@@ -140,20 +120,10 @@
         "type": "color",
         "description": "Primary links"
       },
-      "Link01Dark": {
-        "value": "#177EE5",
-        "type": "color",
-        "description": "Primary links - Dark"
-      },
       "Link02": {
         "value": "#A4A5A6",
         "type": "color",
         "description": "Secondary links"
-      },
-      "Link02Dark": {
-        "value": "#A4A5A6",
-        "type": "color",
-        "description": "Secondary links - Dark"
       }
     },
     "Border": {
@@ -162,30 +132,15 @@
         "type": "color",
         "description": "List border color, Container border"
       },
-      "UiBorder01Dark": {
-        "value": "#5C6366",
-        "type": "color",
-        "description": "List border color, Container border - Dark"
-      },
       "UiBorder02": {
         "value": "#CACCCD",
         "type": "color",
         "description": "Button border, Input border"
       },
-      "UiBorder02Dark": {
-        "value": "#838789",
-        "type": "color",
-        "description": "Button border, Input border - Dark"
-      },
       "UiBorder03": {
         "value": "#A4A5A6",
         "type": "color",
         "description": "Checkbox border, Input border"
-      },
-      "UiBorder03Dark": {
-        "value": "#838789",
-        "type": "color",
-        "description": "Checkbox border, Input border - Dark"
       },
       "UiBorder04": {
         "value": "#838789",
@@ -209,16 +164,6 @@
         "type": "color",
         "description": "Side navigation background in lighter hue"
       },
-      "UiBackground01Dark": {
-        "value": "#2F3233",
-        "type": "color",
-        "description": "Default page background - Dark"
-      },
-      "UiBackground02Dark": {
-        "value": "#454A4D",
-        "type": "color",
-        "description": "Side navigation background - Dark"
-      },
       "UiBackground02Blue": {
         "value": "#F1F7FD",
         "type": "color",
@@ -229,60 +174,30 @@
         "type": "color",
         "description": "info message background"
       },
-      "UiBackgroundBlueDark": {
-        "value": "#115CA7",
-        "type": "color",
-        "description": "info message background - Dark"
-      },
       "UiBackgroundGray": {
         "value": "#F3F4F5",
         "type": "color",
         "description": "message background"
-      },
-      "UiBackgroundGrayDark": {
-        "value": "#838789",
-        "type": "color",
-        "description": "message background - Dark"
       },
       "UiBackgroundSuccess": {
         "value": "#ECFBF4",
         "type": "color",
         "description": "Success message background"
       },
-      "UiBackgroundSuccessDark": {
-        "value": "#1E8353",
-        "type": "color",
-        "description": "Success message background - Dark"
-      },
       "UiBackgroundError": {
         "value": "#FCEFF3",
         "type": "color",
         "description": "Error message background"
-      },
-      "UiBackgroundErrorDark": {
-        "value": "#A01D3E",
-        "type": "color",
-        "description": "Error message background - Dark"
       },
       "UiBackgroundWarning": {
         "value": "#FFFADC",
         "type": "color",
         "description": "Warning message background"
       },
-      "UiBackgroundWarningDark": {
-        "value": "#A68A00",
-        "type": "color",
-        "description": "Warning message background - Dark"
-      },
       "UiBackgroundTooltip": {
         "value": "#2F3233",
         "type": "color",
         "description": "ToolTip background"
-      },
-      "UiBackgroundTooltipDark": {
-        "value": "#F3F4F5",
-        "type": "color",
-        "description": "ToolTip background - Dark"
       },
       "BackgroundOverlayGray": {
         "value": "#2f323380",
@@ -301,30 +216,15 @@
         "type": "color",
         "description": "Primary icons"
       },
-      "Icon01Dark": {
-        "value": "#CACCCD",
-        "type": "color",
-        "description": "Primary icons - Dark"
-      },
       "Icon02": {
         "value": "#A4A5A6",
         "type": "color",
         "description": "Secondary icons"
       },
-      "Icon02Dark": {
-        "value": "#838789",
-        "type": "color",
-        "description": "Secondary icons - Dark"
-      },
       "Icon03": {
         "value": "#CACCCD",
         "type": "color",
         "description": "Tertiary icons, icon button default state"
-      },
-      "Icon03Dark": {
-        "value": "#5C6366",
-        "type": "color",
-        "description": "Tertiary icons, icon button default state - Dark"
       },
       "IconOnColor": {
         "value": "#FFFFFF",
@@ -343,35 +243,15 @@
         "type": "color",
         "description": "Primary Interactive color on background, Primary fill buttons"
       },
-      "Interactive01Dark": {
-        "value": "#9FCBF5",
-        "type": "color",
-        "description": "Primary Interactive color, Primary buttons - Dark"
-      },
-      "InteractiveBg01Dark": {
-        "value": "#177EE5",
-        "type": "color",
-        "description": "Primary Interactive color on background, Primary fill buttons - Dark"
-      },
       "Interactive02": {
         "value": "#6F7476",
         "type": "color",
         "description": "Secondary Interactive color, Secondary buttons"
       },
-      "Interactive02Dark": {
-        "value": "#CACCCD",
-        "type": "color",
-        "description": "Secondary Interactive color, Secondary buttons -Dark"
-      },
       "Interactive03": {
         "value": "#177EE5",
         "type": "color",
         "description": "Tertiary button, Selected elements, Active elements, Accent icon"
-      },
-      "Interactive03Dark": {
-        "value": "#838789",
-        "type": "color",
-        "description": "Tertiary button, Selected elements, Active elements, Accent icon -Dark"
       },
       "Interactive04": {
         "value": "#CACCCD",
@@ -385,20 +265,10 @@
         "type": "color",
         "description": "Default input fields"
       },
-      "FieldInputDark": {
-        "value": "#2F3233",
-        "type": "color",
-        "description": "Default input fields - Dark"
-      },
       "FieldSearch": {
         "value": "#FFFFFF",
         "type": "color",
         "description": "Search input fields"
-      },
-      "FieldSearchDark": {
-        "value": "#5C6366",
-        "type": "color",
-        "description": "Search input fields - Dark"
       }
     },
     "Focus": {
@@ -406,11 +276,6 @@
         "value": "#177EE5",
         "type": "color",
         "description": "Focus border, Focus underline"
-      },
-      "FocusDark": {
-        "value": "#177EE5",
-        "type": "color",
-        "description": "Focus border, Focus underline - Dark"
       }
     },
     "Hover": {
@@ -419,120 +284,60 @@
         "type": "color",
         "description": "$interactive-01 hover"
       },
-      "Hover01Dark": {
-        "value": "#1366B9",
-        "type": "color",
-        "description": "$interactive-01 hover - Dark"
-      },
       "Hover02": {
         "value": "#E9EAEB",
         "type": "color",
         "description": "$interactive-02 hover"
-      },
-      "Hover02Dark": {
-        "value": "#5C6366",
-        "type": "color",
-        "description": "$interactive-02 hover - Dark"
       },
       "Hover02Background": {
         "value": "#E9EAEB",
         "type": "color",
         "description": "$interactive-02 hover on background"
       },
-      "Hover02BackgroundDark": {
-        "value": "#454A4D",
-        "type": "color",
-        "description": "$interactive-02 hover on background - Dark"
-      },
       "HoverUi": {
         "value": "#E9EAEB",
         "type": "color",
         "description": "hover ui background"
-      },
-      "HoverUiDark": {
-        "value": "#5C6366",
-        "type": "color",
-        "description": "hover ui background - Dark"
       },
       "HoverUi02": {
         "value": "#F3F4F5",
         "type": "color",
         "description": "hover ui background with lighter color"
       },
-      "HoverUi02Dark": {
-        "value": "#454A4D",
-        "type": "color",
-        "description": "hover ui background with darker color"
-      },
       "HoverUiBorder": {
         "value": "#6F7476",
         "type": "color",
-        "description": "hover ui background - Dark"
-      },
-      "HoverUiBorderDark": {
-        "value": "#CACCCD",
-        "type": "color",
-        "description": "hover ui background - Dark"
+        "description": "hover ui border"
       },
       "HoverSelectedUi": {
         "value": "#CACCCD",
         "type": "color",
         "description": "Checkbox border color"
       },
-      "HoverSelectedUiDark": {
-        "value": "#838789",
-        "type": "color",
-        "description": "Checkbox border color - Dark"
-      },
       "HoverDanger": {
         "value": "#B22045",
         "type": "color",
         "description": "Danger hover"
-      },
-      "HoverDangerDark": {
-        "value": "#B22045",
-        "type": "color",
-        "description": "Danger hover - Dark"
       },
       "HoverError": {
         "value": "#B22045",
         "type": "color",
         "description": "Error hover"
       },
-      "HoverErrorDark": {
-        "value": "#F9E0E6",
-        "type": "color",
-        "description": "Error hover - Dark"
-      },
       "HoverInput": {
         "value": "#6F7476",
         "type": "color",
         "description": "hover input"
-      },
-      "HoverInputDark": {
-        "value": "#A4A5A6",
-        "type": "color",
-        "description": "hover input - Dark"
       },
       "HoverLink01": {
         "value": "#1366B9",
         "type": "color",
         "description": "hover primary link"
       },
-      "HoverLink01Dark": {
-        "value": "#9FCBF5",
-        "type": "color",
-        "description": "hover primary link - Dark"
-      },
       "HoverLink02": {
         "value": "#6F7476",
         "type": "color",
         "description": "hover secondary link"
-      },
-      "HoverLink02Dark": {
-        "value": "#DEDFE0",
-        "type": "color",
-        "description": "hover secondary link - Dark"
       },
       "HoverGray": {
         "value": "#454A4D",
@@ -546,90 +351,45 @@
         "type": "color",
         "description": "$interactive-01 active"
       },
-      "Active01Dark": {
-        "value": "#0E4B87",
-        "type": "color",
-        "description": "$interactive-01 active - Dark"
-      },
       "Active02": {
         "value": "#CACCCD",
         "type": "color",
         "description": "$interactive-02 active"
-      },
-      "Active02Dark": {
-        "value": "#838789",
-        "type": "color",
-        "description": "$interactive-02 active - Dark"
       },
       "Active02Background": {
         "value": "#DEDFE0",
         "type": "color",
         "description": "$interactive-02 active on background"
       },
-      "Active02BackgroundDark": {
-        "value": "#5C6366",
-        "type": "color",
-        "description": "$interactive-02 active on background - Dark"
-      },
       "ActiveUi": {
         "value": "#D9EAFB",
         "type": "color",
         "description": "Active List background color"
-      },
-      "ActiveUiDark": {
-        "value": "#838789",
-        "type": "color",
-        "description": "Active List background color - Dark"
       },
       "ActiveSelectedUi": {
         "value": "#177EE5",
         "type": "color",
         "description": "Checkbox background color, Select border color"
       },
-      "ActiveSelectedUiDark": {
-        "value": "#177EE5",
-        "type": "color",
-        "description": "Checkbox background color, Select border color - Dark"
-      },
       "ActiveDanger": {
         "value": "#821732",
         "type": "color",
         "description": "Danger active"
-      },
-      "ActiveDangerDark": {
-        "value": "#821732",
-        "type": "color",
-        "description": "Danger active - Dark"
       },
       "ActiveInput": {
         "value": "#1366B9",
         "type": "color",
         "description": "Active input"
       },
-      "ActiveInputDark": {
-        "value": "#CACCCD",
-        "type": "color",
-        "description": "Active input - Dark"
-      },
       "ActiveLink01": {
         "value": "#0E4B87",
         "type": "color",
         "description": "active primary link"
       },
-      "ActiveLink01Dark": {
-        "value": "#D9EAFB",
-        "type": "color",
-        "description": "active primary link - Dark"
-      },
       "ActiveLink02": {
         "value": "#2F3233",
         "type": "color",
         "description": "active secondary link"
-      },
-      "ActiveLink02Dark": {
-        "value": "#E9EAEB",
-        "type": "color",
-        "description": "active secondary link - Dark"
       }
     },
     "Selected": {
@@ -638,20 +398,10 @@
         "type": "color",
         "description": "Selected List Navigation"
       },
-      "SelectedUiDark": {
-        "value": "#1366B9",
-        "type": "color",
-        "description": "Selected List Navigation - Dark"
-      },
       "SelectedUiGray": {
         "value": "#DEDFE0",
         "type": "color",
         "description": "Selected List Navigation Gray"
-      },
-      "SelectedUiGrayDark": {
-        "value": "#838789",
-        "type": "color",
-        "description": "Selected List Navigation Gray - Dark"
       },
       "SelectedUiOnColor": {
         "value": "#FFFFFF",
@@ -662,11 +412,6 @@
         "value": "#177EE5",
         "type": "color",
         "description": "Selected Button Border"
-      },
-      "SelectedUiBorderDark": {
-        "value": "#9FCBF5",
-        "type": "color",
-        "description": "Selected Button Border - Dark"
       }
     },
     "Disabled": {
@@ -675,20 +420,10 @@
         "type": "color",
         "description": "Disabled text, Disabled border"
       },
-      "Disabled01Dark": {
-        "value": "#5C6366",
-        "type": "color",
-        "description": "Disabled text, Disabled border - Dark"
-      },
       "Disabled02": {
         "value": "#F3F4F5",
         "type": "color",
         "description": "Text on disabled button"
-      },
-      "Disabled02Dark": {
-        "value": "#838789",
-        "type": "color",
-        "description": "Text on disabled button - Dark"
       },
       "Disabled03": {
         "value": "#454A4D",
@@ -710,25 +445,10 @@
         "type": "color",
         "description": "Disabled secondary links"
       },
-      "DisabledLink01Dark": {
-        "value": "#115CA7",
-        "type": "color",
-        "description": "Disabled primary links - Dark"
-      },
-      "DisabledLink02Dark": {
-        "value": "#5C6366",
-        "type": "color",
-        "description": "Disabled secondary links - Dark"
-      },
       "DisabledOn": {
         "value": "#D9EAFB",
         "type": "color",
         "description": "Disabled on state"
-      },
-      "DisabledOnDark": {
-        "value": "#9FCBF5",
-        "type": "color",
-        "description": "Disabled on state - Dark"
       }
     },
     "Support": {
@@ -742,11 +462,6 @@
         "type": "color",
         "description": "Error light color"
       },
-      "SupportErrorDark": {
-        "value": "#E67490",
-        "type": "color",
-        "description": "Error text, Icon with error, error element border - Dark"
-      },
       "SupportSuccess": {
         "value": "#2DC87D",
         "type": "color",
@@ -756,11 +471,6 @@
         "value": "#CCF4E1",
         "type": "color",
         "description": "Success light color"
-      },
-      "SupportSuccessDark": {
-        "value": "#69DDA5",
-        "type": "color",
-        "description": "Success text, button background, button border - Dark"
       },
       "SupportInfo": {
         "value": "#177EE5",
@@ -772,11 +482,6 @@
         "type": "color",
         "description": "Information light color"
       },
-      "SupportInfoDark": {
-        "value": "#177EE5",
-        "type": "color",
-        "description": "Information text, button background, button border - Dark"
-      },
       "SupportWarning": {
         "value": "#FCD200",
         "type": "color",
@@ -787,11 +492,6 @@
         "type": "color",
         "description": "Warning light color"
       },
-      "SupportWarningDark": {
-        "value": "#FFE976",
-        "type": "color",
-        "description": "Warning text, Icon with error, error element border - Dark"
-      },
       "SupportDanger": {
         "value": "#D92B57",
         "type": "color",
@@ -801,11 +501,6 @@
         "value": "#F4BFCD",
         "type": "color",
         "description": "Danger light color"
-      },
-      "SupportDangerDark": {
-        "value": "#E67490",
-        "type": "color",
-        "description": "Danger text, button background, button border - Dark"
       }
     }
   },


### PR DESCRIPTION
# 概要

PR #434（ダークモードトークン削除）の後続作業として、`yarn build:tokens` を実行してデザイントークンシステムの変更を build 成果物に反映しました。

## 変更内容

### トークンビルドの反映

- `yarn build:tokens` を実行してトークン削除が実際のファイルに反映
- `packages/component-config/src/tokens/tokens.ts` からダークモード関連トークンが削除
- `packages/component-config/style-dictionary/transformed-tokens.json` も同様に更新

### 削除されたダークモードトークン（実際にビルドから削除）

以下のカテゴリーのダークモードトークンが実際にビルド成果物から削除されました：

- **Text**: `text01Dark`, `text02Dark`, `text03Dark`, `textPlaceholderDark`
- **Link**: `link01Dark`, `link02Dark`
- **Border**: `uiBorder01Dark`, `uiBorder02Dark`, `uiBorder03Dark`
- **Background**: `uiBackground01Dark`, `uiBackground02Dark`, `uiBackgroundBlueDark`, `uiBackgroundGrayDark`, `uiBackgroundSuccessDark`, `uiBackgroundErrorDark`, `uiBackgroundWarningDark`, `uiBackgroundTooltipDark`
- **Icon**: `icon01Dark`, `icon02Dark`, `icon03Dark`
- **Interactive**: `interactive01Dark`, `interactiveBg01Dark`, `interactive02Dark`, `interactive03Dark`
- **Field**: `fieldInputDark`, `fieldSearchDark`
- **Focus**: `focusDark`
- **Hover**: `hover01Dark`, `hover02Dark`, `hover02BackgroundDark`, `hoverUiDark`, `hoverUi02Dark`, `hoverUiBorderDark`, `hoverSelectedUiDark`, `hoverDangerDark`, `hoverErrorDark`, `hoverInputDark`, `hoverLink01Dark`, `hoverLink02Dark`
- **Active**: `active01Dark`, `active02Dark`, `active02BackgroundDark`, `activeUiDark`, `activeSelectedUiDark`, `activeDangerDark`, `activeInputDark`, `activeLink01Dark`, `activeLink02Dark`
- **Selected**: `selectedUiDark`, `selectedUiGrayDark`, `selectedUiBorderDark`
- **Disabled**: `disabled01Dark`, `disabled02Dark`, `disabledLink01Dark`, `disabledLink02Dark`, `disabledOnDark`
- **Support**: `supportErrorDark`, `supportSuccessDark`, `supportInfoDark`, `supportWarningDark`, `supportDangerDark`

### その他の修正

- `HoverUiBorder` の説明文を修正（"hover ui background - Dark" → "hover ui border"）

## 実施内容

```bash
yarn build:tokens
```

## 影響範囲

- デザイントークンシステムの build 成果物
- TypeScript型定義ファイル
- Style Dictionary の変換済みトークン

## 関連PR

- PR #434: ダークモードトークン削除（前提作業）

## 破壊的変更

なし。PR #434で既にダークモードトークンは削除済みのため、今回はビルドでの反映のみです。

## テスト

- ビルドが正常に完了
- 既存コンポーネントがライトモードで正常に表示されることを確認
- ダークモードトークンを参照しているコードがないことを確認
