### PR TITLE
68｜68-1, 68-2｜Fix WCAG 2.1 contrast ratio compliance

### DIFF
--- a/packages/component-config/src/tokens/tokens.ts
+++ b/packages/component-config/src/tokens/tokens.ts
@@ -23,8 +23,8 @@ export const tokens = {
   },
   "tokens": {
     "text": {
-      "text01": "#2F3233",
-      "text02": "#6F7476",
+      "text01": "#1F2121",
+      "text02": "#5C6366",
       "text03": "#838789",
       "textPlaceholder": "#CACCCD",
       "textOnColor": "#FFFFFF",
@@ -50,8 +50,8 @@ export const tokens = {
       "uiBackgroundSuccess": "#ECFBF4",
       "uiBackgroundError": "#FCEFF3",
       "uiBackgroundWarning": "#FFFADC",
-      "uiBackgroundTooltip": "#2F3233",
-      "backgroundOverlayGray": "#2f323380",
+      "uiBackgroundTooltip": "#1F2121",
+      "backgroundOverlayGray": "#1f212180",
       "backgroundOverlayBlack": "#00000099"
     },
     "icon": {
@@ -98,7 +98,7 @@ export const tokens = {
       "activeDanger": "#821732",
       "activeInput": "#1366B9",
       "activeLink01": "#0E4B87",
-      "activeLink02": "#2F3233"
+      "activeLink02": "#1F2121"
     },
     "selected": {
       "selectedUi": "#D9EAFB",
@@ -154,7 +154,7 @@ export const tokens = {
       "gray70": "#6F7476",
       "gray80": "#5C6366",
       "gray90": "#454A4D",
-      "gray100": "#2F3233"
+      "gray100": "#1F2121"
     },
     "red": {
       "red10": "#FCEFF3",

--- a/packages/component-config/style-dictionary/tokens.json
+++ b/packages/component-config/style-dictionary/tokens.json
@@ -90,7 +90,7 @@
           "description": "Primary text, Body copy, Headers"
         },
         "Text02": {
-          "value": "$Colors.Gray.Gray70",
+          "value": "$Colors.Gray.Gray80",
           "type": "color",
           "description": "Secondary text, Input labels"
         },
@@ -680,7 +680,7 @@
           "description": ""
         },
         "Gray100": {
-          "value": "#2F3233",
+          "value": "#1F2121",
           "type": "color",
           "description": ""
         }

--- a/packages/component-config/style-dictionary/transformed-tokens.json
+++ b/packages/component-config/style-dictionary/transformed-tokens.json
@@ -84,12 +84,12 @@
   "Tokens": {
     "Text": {
       "Text01": {
-        "value": "#2F3233",
+        "value": "#1F2121",
         "type": "color",
         "description": "Primary text, Body copy, Headers"
       },
       "Text02": {
-        "value": "#6F7476",
+        "value": "#5C6366",
         "type": "color",
         "description": "Secondary text, Input labels"
       },
@@ -195,12 +195,12 @@
         "description": "Warning message background"
       },
       "UiBackgroundTooltip": {
-        "value": "#2F3233",
+        "value": "#1F2121",
         "type": "color",
         "description": "ToolTip background"
       },
       "BackgroundOverlayGray": {
-        "value": "#2f323380",
+        "value": "#1f212180",
         "type": "color",
         "description": "Background overlay"
       },
@@ -387,7 +387,7 @@
         "description": "active primary link"
       },
       "ActiveLink02": {
-        "value": "#2F3233",
+        "value": "#1F2121",
         "type": "color",
         "description": "active secondary link"
       }
@@ -618,7 +618,7 @@
         "description": ""
       },
       "Gray100": {
-        "value": "#2F3233",
+        "value": "#1F2121",
         "type": "color",
         "description": ""
       }


### PR DESCRIPTION
## 概要

WCAG 2.1のコントラスト比要件を満たすため、テキストカラーとグレーカラーの値を調整しました。

## 変更内容

### 手動で編集したファイル
- `packages/component-config/style-dictionary/tokens.json`
  - Text02の参照値を`$Colors.Gray.Gray70` → `$Colors.Gray.Gray80`に変更
  - Gray100の値を`#2F3233` → `#1F2121`に変更

### 自動生成されたファイル
以下のファイルは上記の変更に基づいてbuild処理で自動更新されました：
- `packages/component-config/src/tokens/tokens.ts`
- `packages/component-config/style-dictionary/transformed-tokens.json`

## 変更の詳細

### カラー値の変更
- **Text01**: `#2F3233` → `#1F2121` (より暗い灰色でコントラストを向上)
- **Text02**: `#6F7476` → `#5C6366` (より暗い灰色でコントラストを向上)
- **UiBackgroundTooltip**: `#2F3233` → `#1F2121` (Text01と同様)
- **BackgroundOverlayGray**: `#2f323380` → `#1f212180` (透明度付きで同様の調整)
- **ActiveLink02**: `#2F3233` → `#1F2121` (Text01と同様)
- **Gray100**: `#2F3233` → `#1F2121` (基準色の調整)

## 影響範囲

この変更により、以下の要素のコントラスト比が改善されます：
- プライマリテキスト（Text01）
- セカンダリテキスト（Text02）
- ツールチップの背景色
- オーバーレイの背景色
- アクティブなセカンダリリンク

## 確認事項

- [ ] WCAG 2.1のコントラスト比要件（4.5:1以上）を満たしていることを確認
- [ ] デザインシステム全体で一貫性が保たれていることを確認
- [ ] 既存のコンポーネントでの表示に問題がないことを確認

## 備考

この変更はコンポーネントライブラリのアクセシビリティ向上を目的としており、既存のUIの視覚的な変更を伴います。