### PR TITLE
68｜68-3｜Fix WCAG 2.1 contrast ratio compliance

### DIFF
--- a/packages/component-ui/src/pagination-select/pagination-select.tsx
+++ b/packages/component-ui/src/pagination-select/pagination-select.tsx
@@ -69,7 +69,7 @@ export function PaginationSelect({
             <Select.Option key={option.id} option={option} />
           ))}
         </Select>
-        <div className="typography-label14regular text-text03">
+        <div className="typography-label14regular text-text02">
           / {pageMax}
           {pageLabel}
         </div>


### PR DESCRIPTION
## 概要

color token `text03` の廃止に向けて、`text03` を `text02` に置き換える作業を実施しました。
WCAG2コントラスト要件への対応として、より適切なコントラスト比を持つトークンへの統一を図ります。

## 変更内容

### 変更ファイル
- `packages/component-ui/src/pagination-select/pagination-select.tsx`

### 変更詳細
- pagination-selectコンポーネント内のページ数表示部分で使用していた `text-text03` クラスを `text-text02` に変更

```diff
-        <div className="typography-label14regular text-text03">
+        <div className="typography-label14regular text-text02">
           / {pageMax}
           {pageLabel}
         </div>
```

## 影響範囲

- pagination-selectコンポーネントのページ数表示のテキストカラーが変更されます
- より適切なコントラスト比により、アクセシビリティが向上します

## 検証項目

- [ ] pagination-selectコンポーネントの表示確認
- [ ] コントラスト比がWCAG2要件を満たしているか確認
- [ ] 他のコンポーネントとのデザイン整合性確認

## 関連

- color token text03 廃止に向けた一連の作業の一環
- WCAG2コントラスト改善対応