### PR TITLE
feat: Make firstName and lastName optional in Avatar component

### DIFF
--- a/docs/component/avatar-specification.md
+++ b/docs/component/avatar-specification.md
@@ -52,19 +52,14 @@ const MyComponent = () => {
 
 ## Props
 
-### 必須プロパティ
-
-| プロパティ  | 型       | 説明           |
-| ----------- | -------- | -------------- |
-| `firstName` | `string` | ユーザーの名前 |
-| `lastName`  | `string` | ユーザーの姓   |
-
 ### オプションプロパティ
 
 | プロパティ   | 型                                                         | デフォルト値 | 説明                       |
 | ------------ | ---------------------------------------------------------- | ------------ | -------------------------- |
 | `size`       | `'x-small' \| 'small' \| 'medium' \| 'large' \| 'x-large'` | `'medium'`   | アバターのサイズ           |
 | `userId`     | `number`                                                   | `undefined`  | ユーザーID（色分けに使用） |
+| `firstName`  | `string`                                                   | `undefined`  | ユーザーの名前             |
+| `lastName`   | `string`                                                   | `undefined`  | ユーザーの姓               |
 | `isDisabled` | `boolean`                                                  | `false`      | 無効状態かどうか           |
 
 ## 状態とスタイル
@@ -178,6 +173,28 @@ const MyComponent = () => {
 />
 ```
 
+### 名前なし（アイコン表示）
+
+`firstName` と `lastName` の両方が未定義または空文字の場合、`user-one` アイコンが表示されます：
+
+```typescript
+<div className="flex gap-2">
+  <Avatar size="x-small" userId={1} />
+  <Avatar size="small" userId={1} />
+  <Avatar size="medium" userId={1} />
+  <Avatar size="large" userId={1} />
+  <Avatar size="x-large" userId={1} />
+</div>
+```
+
+```typescript
+<div className="flex gap-2">
+  <Avatar size="medium" />
+  <Avatar size="medium" isDisabled />
+  <Avatar size="medium" userId={1} isDisabled />
+</div>
+```
+
 ### 特殊な名前パターン
 
 #### 英語名（ASCII文字）
@@ -233,18 +250,32 @@ const MyComponent = () => {
 - `isAsciiString`関数による文字コード判定（ASCII文字の判定）
 - 名前の正規化処理（全角スペースの変換、トリム処理）
 - ユーザーカラーの循環選択（モジュロ演算）
+- 名前がない場合のアイコン表示ロジック
 
-### 名前表示ロジック
+### 表示ロジック
 
 ```typescript
+// 名前の有無を判定
+const hasName = (props.firstName != null && props.firstName.trim() !== '') ||
+                (props.lastName != null && props.lastName.trim() !== '');
+
+// 名前がない場合はアイコンを表示
+if (hasName === false) {
+  return (
+    <span className={classes}>
+      <Icon name="user-one" size={iconSizeMap[size]} color="iconOnColor" />
+    </span>
+  );
+}
+
 // ASCII文字判定
 const isAsciiString = (str: string) => {
   return str.charCodeAt(0) < 256;
 };
 
 // 名前の正規化
-const trimmedFirstName = props.firstName.replace('　', ' ').trim();
-const trimmedLastName = props.lastName.replace('　', ' ').trim();
+const trimmedFirstName = (props.firstName ?? '').replace('　', ' ').trim();
+const trimmedLastName = (props.lastName ?? '').replace('　', ' ').trim();
 
 // 表示文字の決定
 const nameOnIcon = isAsciiString(trimmedLastName)
@@ -254,11 +285,12 @@ const nameOnIcon = isAsciiString(trimmedLastName)
 
 ## 注意事項
 
-1. **名前の必須性**: `firstName`と`lastName`は必須プロパティです
+1. **名前のオプション性**: `firstName`と`lastName`はオプションプロパティです。両方が未定義または空文字の場合、`user-one`アイコンが表示されます
 2. **文字数制限**: 表示されるイニシャルは最大2文字です
 3. **色の循環**: ユーザーカラーは10色で循環するため、同じ色が複数のユーザーに割り当てられる可能性があります
 4. **ASCII文字判定**: 姓の最初の文字がASCII文字かどうかで表示ロジックが変わります
 5. **全角スペース処理**: 全角スペース（　）は自動的に半角スペースに変換されます
+6. **アイコン表示**: 名前がない場合は`user-one`アイコンが表示され、Avatarのサイズに応じてアイコンサイズも調整されます
 
 ## スタイルのカスタマイズ
 
@@ -273,6 +305,7 @@ const nameOnIcon = isAsciiString(trimmedLastName)
 
 ## 更新履歴
 
-| 日付       | 内容     | 担当者 |
-| ---------- | -------- | ------ |
-| 2025-10-06 | 新規作成 | -      |
+| 日付       | 内容                                                                                                | 担当者 |
+| ---------- | --------------------------------------------------------------------------------------------------- | ------ |
+| 2025-10-06 | firstName, lastNameを必須からオプションに変更。名前なしの場合はuser-oneアイコンを表示する機能を追加 | -      |
+| 2025-10-06 | 新規作成                                                                                            | -      |

--- a/packages/component-ui/src/avatar/avatar.stories.tsx
+++ b/packages/component-ui/src/avatar/avatar.stories.tsx
@@ -58,6 +58,19 @@ export function Base() {
         <Avatar size="medium" userId={1} lastName="全 優" firstName="" />
         <Avatar size="medium" userId={1} lastName="全　優" firstName="" />
       </div>
+      {/* 名前なしパターン（アイコン表示） */}
+      <div className="flex gap-2">
+        <Avatar size="x-small" userId={1} />
+        <Avatar size="small" userId={1} />
+        <Avatar size="medium" userId={1} />
+        <Avatar size="large" userId={1} />
+        <Avatar size="x-large" userId={1} />
+      </div>
+      <div className="flex gap-2">
+        <Avatar size="medium" />
+        <Avatar size="medium" isDisabled />
+        <Avatar size="medium" userId={1} isDisabled />
+      </div>
     </div>
   );
 }

--- a/packages/component-ui/src/avatar/avatar.test.tsx
+++ b/packages/component-ui/src/avatar/avatar.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { Avatar } from './avatar';
+
+describe('Avatar', () => {
+  it('firstName と lastName が指定されている場合、イニシャルが表示されること', () => {
+    render(<Avatar firstName="太郎" lastName="全機現" userId={1} />);
+    expect(screen.getByText('全機')).toBeInTheDocument();
+  });
+
+  it('英語名の場合、姓と名の最初の文字が大文字で表示されること', () => {
+    render(<Avatar firstName="John" lastName="Smith" userId={1} />);
+    expect(screen.getByText('JS')).toBeInTheDocument();
+  });
+
+  it('firstName と lastName の両方が未定義の場合、user-oneアイコンが表示されること', () => {
+    render(<Avatar userId={1} />);
+    const icon = screen.getByRole('img', { name: 'userOne' });
+    expect(icon).toBeInTheDocument();
+  });
+
+  it('firstName と lastName の両方が空文字の場合、user-oneアイコンが表示されること', () => {
+    render(<Avatar firstName="" lastName="" userId={1} />);
+    const icon = screen.getByRole('img', { name: 'userOne' });
+    expect(icon).toBeInTheDocument();
+  });
+
+  it('firstName のみが指定されている場合、イニシャルが表示されること', () => {
+    render(<Avatar firstName="太郎" userId={1} />);
+    expect(screen.getByText('太郎')).toBeInTheDocument();
+  });
+
+  it('lastName のみが指定されている場合、イニシャルが表示されること', () => {
+    render(<Avatar lastName="全機現" userId={1} />);
+    expect(screen.getByText('全機')).toBeInTheDocument();
+  });
+
+  it('isDisabled が true の場合、無効状態のスタイルが適用されること', () => {
+    render(<Avatar firstName="太郎" lastName="全機現" userId={1} isDisabled />);
+    const avatar = screen.getByText('全機').closest('span');
+    expect(avatar).toHaveClass('bg-disabled01');
+  });
+
+  it('userId が未定義の場合、デフォルトの背景色が適用されること', () => {
+    render(<Avatar firstName="太郎" lastName="全機現" />);
+    const avatar = screen.getByText('全機').closest('span');
+    expect(avatar).toHaveClass('bg-icon01');
+  });
+
+  it('size が x-small の場合、適切なサイズクラスが適用されること', () => {
+    render(<Avatar firstName="太郎" lastName="全機現" userId={1} size="x-small" />);
+    const avatar = screen.getByText('全機').closest('span');
+    expect(avatar).toHaveClass('w-6', 'h-6');
+  });
+
+  it('size が x-large の場合、適切なサイズクラスが適用されること', () => {
+    render(<Avatar firstName="太郎" lastName="全機現" userId={1} size="x-large" />);
+    const avatar = screen.getByText('全機').closest('span');
+    expect(avatar).toHaveClass('w-16', 'h-16');
+  });
+
+  it('名前なしで isDisabled が true の場合、アイコンが表示され無効状態のスタイルが適用されること', () => {
+    const { container } = render(<Avatar userId={1} isDisabled />);
+    const icon = screen.getByRole('img', { name: 'userOne' });
+    expect(icon).toBeInTheDocument();
+    const avatar = container.firstChild as HTMLElement;
+    expect(avatar).toHaveClass('bg-disabled01');
+  });
+});

--- a/packages/component-ui/src/avatar/avatar.tsx
+++ b/packages/component-ui/src/avatar/avatar.tsx
@@ -1,6 +1,8 @@
 import { userColors } from '@zenkigen-inc/component-theme';
 import { clsx } from 'clsx';
 
+import { Icon } from '../icon';
+
 export const isAsciiString = (str: string) => {
   return str.charCodeAt(0) < 256;
 };
@@ -8,8 +10,8 @@ export const isAsciiString = (str: string) => {
 type Props = {
   size?: 'x-small' | 'small' | 'medium' | 'large' | 'x-large';
   userId?: number;
-  firstName: string;
-  lastName: string;
+  firstName?: string;
+  lastName?: string;
   isDisabled?: boolean;
 };
 
@@ -26,8 +28,30 @@ export function Avatar({ size = 'medium', ...props }: Props) {
       props.userId != null && !(props.isDisabled ?? false),
   });
 
-  const trimmedFirstName = props.firstName.replace('　', ' ').trim();
-  const trimmedLastName = props.lastName.replace('　', ' ').trim().trim();
+  // firstName と lastName の両方が未定義または空文字の場合はアイコンを表示
+  const hasName =
+    (props.firstName != null && props.firstName.trim() !== '') ||
+    (props.lastName != null && props.lastName.trim() !== '');
+
+  if (hasName === false) {
+    // アイコンサイズのマッピング
+    const iconSizeMap = {
+      'x-small': 'x-small' as const,
+      small: 'small' as const,
+      medium: 'medium' as const,
+      large: 'large' as const,
+      'x-large': 'x-large' as const,
+    };
+
+    return (
+      <span className={classes}>
+        <Icon name="user-one" size={iconSizeMap[size]} color="iconOnColor" />
+      </span>
+    );
+  }
+
+  const trimmedFirstName = (props.firstName ?? '').replace('　', ' ').trim();
+  const trimmedLastName = (props.lastName ?? '').replace('　', ' ').trim();
   const nameOnIcon = isAsciiString(trimmedLastName)
     ? trimmedFirstName.slice(0, 1).toUpperCase() + trimmedLastName.slice(0, 1).toUpperCase()
     : (trimmedLastName + trimmedFirstName).slice(0, 2);


### PR DESCRIPTION
# Avatarコンポーネントの仕様変更: 名前プロパティをオプション化

## 概要

Avatarコンポーネントの`firstName`と`lastName`プロパティを必須からオプションに変更し、名前が指定されていない場合は`user-one`アイコンを表示する機能を追加しました。

## 変更内容

### 機能変更
- `firstName`と`lastName`プロパティを必須からオプションに変更
- 名前が指定されていない場合（両方が未定義または空文字）は`user-one`アイコンを表示
- アイコンサイズはAvatarのサイズに応じて自動調整

### 実装詳細
- 名前の有無を判定するロジックを追加
- アイコン表示時のサイズマッピングを実装
- 既存のイニシャル表示ロジックは維持

### テスト追加
- 名前なしパターンのテストケースを追加
- アイコン表示のテストケースを追加
- 既存のテストケースは全て維持

### ドキュメント更新
- 仕様書の更新（必須プロパティからオプションプロパティへの変更）
- 使用例の追加（名前なしパターン）
- 実装ロジックの詳細説明を追加

## 影響範囲

- `packages/component-ui/src/avatar/avatar.tsx` - メイン実装
- `packages/component-ui/src/avatar/avatar.test.tsx` - テスト追加
- `packages/component-ui/src/avatar/avatar.stories.tsx` - ストーリー追加
- `docs/component/avatar-specification.md` - 仕様書更新

## 後方互換性

- 既存のコードは変更なしで動作します
- `firstName`と`lastName`を指定している既存の使用箇所は影響を受けません

## テスト

- 既存のテストケースは全て通過
- 新規追加したテストケースも全て通過
- Storybookでの表示確認済み

## 確認事項

- [ ] 既存の使用箇所で問題が発生していないか
- [ ] アイコン表示が適切に動作しているか
- [ ] サイズ変更が正しく反映されているか