### PR TITLE
Test：Integrate TextInput component specification into Storybook documentation

### DIFF
--- a/packages/component-ui/src/text-input/Specification.mdx
+++ b/packages/component-ui/src/text-input/Specification.mdx
@@ -2,23 +2,6 @@ import { Canvas, Meta, ArgTypes, Story, Controls, Source, Markdown } from '@stor
 import TextInputStories, { Component, Base } from './text-input.stories';
 import textInputSpec from '../../../../docs/component/text-input-specification.md?raw';
 
-<Meta title="TextInput" of={TextInputStories} />
-
-# TextInput
-
-<Canvas>
-  <Story of={Component} />
-</Canvas>
-
-<Controls of={Component} />
-
-↓畳む。
-
-<details>
-  <summary>詳細仕様書</summary>
-  <Markdown>{textInputSpec}</Markdown>
-</details>
-
-↓そのまま表示
+<Meta title="Components/TextInput/Specification" />
 
 <Markdown>{textInputSpec}</Markdown>


### PR DESCRIPTION
> [!NOTE]
> - Storybook MDX上でのMarkdown表示機能のテスト実装 

## 概要
StorybookのMDXファイル内でMarkdownファイルの内容を動的に表示する機能のテスト実装を行いました。TextInputコンポーネントを対象として、仕様書の統合方法を検証しています。

## テスト目的
- StorybookのMDXファイル内でMarkdownコンポーネントを使用した動的コンテンツ表示の動作確認
- `?raw`インポートを使用したMarkdownファイルの読み込み機能の検証
- 畳み込み機能付きの仕様書表示の実装パターンの検証

## 実装内容

### テスト対象コンポーネント
- **TextInputコンポーネント**
  - 既存のDocs.mdxにMarkdown表示機能を追加
  - 専用のSpecification.mdxページを新規作成

### 実装した機能
1. **動的Markdown表示**
   - `@storybook/blocks`の`Markdown`コンポーネントを使用
   - `?raw`インポートでMarkdownファイルの内容を文字列として取得

2. **畳み込み機能付き表示**
   - HTMLの`<details>`タグを使用した畳み込み可能な仕様書セクション
   - ユーザビリティを考慮した表示形式の実装

3. **専用ページの作成**
   - 仕様書のみを表示する専用のMDXページ
   - コンポーネント仕様の詳細確認用

## 技術的な検証項目

### 実装方法の検証
- [x] `import textInputSpec from '../../../../docs/component/text-input-specification.md?raw'` の動作確認
- [x] `<Markdown>{textInputSpec}</Markdown>` での表示確認
- [x] `<details>`タグを使用した畳み込み機能の動作確認

### ファイル構成の検証
```
packages/component-ui/src/text-input/
├── Docs.mdx (更新 - 畳み込み機能付き仕様書表示を追加)
├── Specification.mdx (新規 - 専用仕様書ページ)
└── text-input.stories.tsx
```

## 期待される検証結果
- Storybook内でMarkdownファイルの内容が正しく表示される
- 畳み込み機能が正常に動作する
- 専用ページが適切に表示される
- 他のコンポーネントへの適用可能性の確認

## 今後の展開
このテスト実装の結果を基に、以下の検討を行います：
- 他のコンポーネントへの同様の仕様書統合
- より効率的なMarkdown表示パターンの確立
- コンポーネントドキュメントの標準化

## テスト環境での確認事項
- [ ] Storybookのビルドが正常に完了する
- [ ] Markdownコンテンツが正しくレンダリングされる
- [ ] 畳み込み機能の動作確認
- [ ] 専用ページの表示確認
- [ ] パフォーマンスへの影響確認

## 備考
このPRは機能テストを目的としており、実装パターンの検証が主目的です。テスト結果に基づいて、本格的な仕様書統合の実装方針を決定します。