### PR TITLE
fix(tokens): rebuild supportSuccess token value in tokensWithMeta

### DIFF
--- a/packages/component-config/src/tokens/tokens.ts
+++ b/packages/component-config/src/tokens/tokens.ts
@@ -1036,10 +1036,10 @@ export const tokensWithMeta = {
         "type": "color"
       },
       "supportSuccess": {
-        "value": "#2dc87d",
+        "value": "#29b471",
         "description": "Success text, button background, button border",
         "type": "color",
-        "rawValue": "$Colors.Green.Green50"
+        "rawValue": "$Colors.Green.Green60"
       },
       "supportSuccessLight": {
         "value": "#ccf4e1",

--- a/packages/component-config/style-dictionary/transformed-tokens.json
+++ b/packages/component-config/style-dictionary/transformed-tokens.json
@@ -575,7 +575,7 @@
         "value": "#29B471",
         "type": "color",
         "description": "Success text, button background, button border",
-        "rawValue": "$Colors.Green.Green50"
+        "rawValue": "$Colors.Green.Green60"
       },
       "SupportSuccessLight": {
         "value": "#CCF4E1",


### PR DESCRIPTION
## 概要

`tokensWithMeta` セクションの `supportSuccess` トークンが古い値のままになっていたため、`yarn update-tokens` を再実行してビルド生成物を更新。

## 背景

| PR | マージ日 | 内容 |
|---|---|---|
| #494 | 2025-12-15 | `supportSuccess` の参照先を `Green50 (#2dc87d)` → `Green60 (#29b471)` に変更 |
| #515 | 2026-03-11 | `tokensWithMeta` セクションを新設（value + description + rawValue 付き） |

#494 で `tokens` セクション（フラット値）は `#29b471` に更新済みだったが、#515 で `tokensWithMeta` を新設・ビルドした際に旧値 `Green50 (#2dc87d)` のまま生成されていた。

## 影響範囲

`tokensWithMeta` は Storybook のカラードキュメント表示用のメタデータであり、実際のコンポーネントのスタイリングに使用される `tokens`（フラット値）には影響しない。そのため、ライブラリ利用側のランタイムへの影響はなく、Storybook 上のトークン情報表示の正確性のみに関わる修正。

## 変更内容

- `tokensWithMeta.supportSuccess.value`: `#2dc87d` → `#29b471`
- `tokensWithMeta.supportSuccess.rawValue`: `$Colors.Green.Green50` → `$Colors.Green.Green60`
- `transformed-tokens.json` の `rawValue` も同様に修正

## 実行コマンド

```bash
yarn update-tokens && yarn build:all
```