### PR TITLE
273｜Add x-large size variant to Button component

### DIFF
--- a/docs/component/button-specification.md
+++ b/docs/component/button-specification.md
@@ -73,7 +73,7 @@ const MyComponent = () => {
 
 | プロパティ       | 型                                              | デフォルト値 | 説明                           |
 | ---------------- | ----------------------------------------------- | ------------ | ------------------------------ |
-| `size`           | `'small' \| 'medium' \| 'large'`                | `'medium'`   | ボタンのサイズ                 |
+| `size`           | `'small' \| 'medium' \| 'large' \| 'x-large'`   | `'medium'`   | ボタンのサイズ                 |
 | `variant`        | `'fill' \| 'fillDanger' \| 'outline' \| 'text'` | `'fill'`     | ボタンのスタイルバリエーション |
 | `width`          | `CSSProperties['width']`                        | -            | ボタンの幅                     |
 | `isSelected`     | `boolean`                                       | `false`      | 選択状態の制御                 |
@@ -111,6 +111,14 @@ const MyComponent = () => {
 #### large
 
 - 高さ: `h-10` (40px)
+- パディング: `px-4`
+- 行の高さ: `leading-[24px]`
+- タイポグラフィ: `typography-label16regular`
+- アイコンサイズ: `medium`（推奨）
+
+#### x-large
+
+- 高さ: `h-12` (48px)
 - パディング: `px-4`
 - 行の高さ: `leading-[24px]`
 - タイポグラフィ: `typography-label16regular`
@@ -378,6 +386,7 @@ Buttonコンポーネントのスタイルは`@zenkigen-inc/component-theme`の`
 
 | 日付                 | 内容                                                                                    | 担当者 |
 | -------------------- | --------------------------------------------------------------------------------------- | ------ |
+| 2026-04-06           | `x-large` サイズバリアントを追加                                                        | -      |
 | 2025-11-26 15:53 JST | `className`プロパティの非推奨化を明記                                                   | -      |
 | 2025-10-29 10:28 JST | 内部実装の詳細を追加、InternalButtonコンポーネントとoutlineDangerバリアントの説明を追加 | -      |
 | 2025-10-29 10:16 JST | 新規作成                                                                                | -      |

--- a/packages/component-ui/src/button/button.stories.tsx
+++ b/packages/component-ui/src/button/button.stories.tsx
@@ -8,7 +8,7 @@ const meta: Meta<typeof Button> = {
   component: Button,
   argTypes: {
     size: {
-      options: ['small', 'medium', 'large'],
+      options: ['small', 'medium', 'large', 'x-large'],
       control: { type: 'radio' },
     },
     variant: {
@@ -89,6 +89,21 @@ export const Fill: Story = {
           ボタンラベル
         </Button>
       </div>
+      <div className="flex items-center gap-2">
+        <Button size="x-large">ボタンラベル</Button>
+        <Button size="x-large" before={<Icon name="add" size="medium" />}>
+          ボタンラベル
+        </Button>
+        <Button size="x-large" after={<Icon name="add" size="medium" />}>
+          ボタンラベル
+        </Button>
+        <Button size="x-large" isDisabled>
+          ボタンラベル
+        </Button>
+        <Button size="x-large" before={<Icon name="add" size="medium" />} isSelected>
+          ボタンラベル
+        </Button>
+      </div>
     </div>
   ),
 };
@@ -142,6 +157,23 @@ export const FillDanger: Story = {
           ボタンラベル
         </Button>
         <Button size="large" variant="fillDanger" before={<Icon name="add" size="small" />} isSelected>
+          ボタンラベル
+        </Button>
+      </div>
+      <div className="flex items-center gap-2">
+        <Button size="x-large" variant="fillDanger">
+          ボタンラベル
+        </Button>
+        <Button size="x-large" variant="fillDanger" before={<Icon name="add" size="medium" />}>
+          ボタンラベル
+        </Button>
+        <Button size="x-large" variant="fillDanger" after={<Icon name="add" size="medium" />}>
+          ボタンラベル
+        </Button>
+        <Button size="x-large" variant="fillDanger" isDisabled>
+          ボタンラベル
+        </Button>
+        <Button size="x-large" variant="fillDanger" before={<Icon name="add" size="medium" />} isSelected>
           ボタンラベル
         </Button>
       </div>
@@ -201,6 +233,23 @@ export const Outline: Story = {
           ボタンラベル
         </Button>
       </div>
+      <div className="flex items-center gap-2">
+        <Button variant="outline" size="x-large">
+          ボタンラベル
+        </Button>
+        <Button variant="outline" size="x-large" before={<Icon name="add" size="medium" />}>
+          ボタンラベル
+        </Button>
+        <Button variant="outline" size="x-large" after={<Icon name="add" size="medium" />}>
+          ボタンラベル
+        </Button>
+        <Button variant="outline" size="x-large" isDisabled>
+          ボタンラベル
+        </Button>
+        <Button variant="outline" size="x-large" before={<Icon name="add" size="medium" />} isSelected>
+          ボタンラベル
+        </Button>
+      </div>
     </div>
   ),
 };
@@ -254,6 +303,23 @@ export const Text: Story = {
           ボタンラベル
         </Button>
         <Button variant="text" size="large" before={<Icon name="add" size="small" />} isSelected>
+          ボタンラベル
+        </Button>
+      </div>
+      <div className="flex items-center gap-2">
+        <Button variant="text" size="x-large">
+          ボタンラベル
+        </Button>
+        <Button variant="text" size="x-large" before={<Icon name="add" size="medium" />}>
+          ボタンラベル
+        </Button>
+        <Button variant="text" size="x-large" after={<Icon name="add" size="medium" />}>
+          ボタンラベル
+        </Button>
+        <Button variant="text" size="x-large" isDisabled>
+          ボタンラベル
+        </Button>
+        <Button variant="text" size="x-large" before={<Icon name="add" size="medium" />} isSelected>
           ボタンラベル
         </Button>
       </div>

--- a/packages/component-ui/src/button/button.test.tsx
+++ b/packages/component-ui/src/button/button.test.tsx
@@ -56,6 +56,17 @@ describe('Button', () => {
     expect(button.style.width).toBe('200px');
   });
 
+  it('size="x-large" の場合、h-12 クラスが適用されること', () => {
+    render(
+      <Button size="x-large" data-testid="xl-button">
+        XLボタン
+      </Button>,
+    );
+    const button = screen.getByTestId('xl-button');
+    expect(button.className).toMatch(/h-12/);
+    expect(button.className).toMatch(/typography-label16regular/);
+  });
+
   it('before, afterの要素が表示されること', () => {
     render(
       <Button before={<span data-testid="before">前</span>} after={<span data-testid="after">後</span>}>

--- a/packages/component-ui/src/button/button.tsx
+++ b/packages/component-ui/src/button/button.tsx
@@ -2,7 +2,7 @@ import { buttonColors, focusVisible } from '@zenkigen-inc/component-theme';
 import { clsx } from 'clsx';
 import type { ComponentPropsWithoutRef, CSSProperties, ElementType, PropsWithChildren, ReactNode } from 'react';
 
-type Size = 'small' | 'medium' | 'large';
+type Size = 'small' | 'medium' | 'large' | 'x-large';
 type Variant = 'fill' | 'fillDanger' | 'outline' | 'text';
 type JustifyContent = 'start' | 'center';
 
@@ -79,6 +79,7 @@ const createButton = <T extends ElementAs = 'button'>(props: InternalProps<T>) =
       'h-6 px-2': size === 'small',
       'h-8 px-3': size === 'medium',
       'h-10 px-4 leading-[24px]': size === 'large',
+      'h-12 px-4 leading-[24px]': size === 'x-large',
       'inline-flex': elementAs === 'a',
       [buttonColors[variant].selected]: isSelected,
       [buttonColors[variant].base]: !isSelected,
@@ -88,8 +89,8 @@ const createButton = <T extends ElementAs = 'button'>(props: InternalProps<T>) =
       'rounded-button': borderRadius == null,
       'justify-start': justifyContent === 'start',
       'justify-center': justifyContent === 'center',
-      'typography-label16regular': size === 'large',
-      'typography-label14regular': size !== 'large',
+      'typography-label16regular': size === 'large' || size === 'x-large',
+      'typography-label14regular': size !== 'large' && size !== 'x-large',
     },
   );
 


### PR DESCRIPTION
## 概要

Button コンポーネントに `x-large` サイズバリアントを追加する。

Figma デザインシステム（ZENKIGEN_Component）に Button の x-large サイズが追加されたため、コード側に反映する。

### x-large サイズの仕様

| プロパティ | Large (既存) | X-Large (今回追加) |
|---|---|---|
| 高さ | 40px (`h-10`) | **48px (`h-12`)** |
| 水平パディング | 16px (`px-4`) | 16px (`px-4`) |
| タイポグラフィ | `typography-label16regular` | `typography-label16regular` |
| アイコンサイズ（推奨） | medium (24x24) | medium (24x24) |
| Gap | 4px (`gap-1`) | 4px (`gap-1`) |
| 角丸 | 4px (`rounded-button`) | 4px (`rounded-button`) |

x-large は large と高さのみ異なり、それ以外のプロパティ（水平パディング、タイポグラフィ、アイコンサイズ、Gap、角丸）は全て large と同一。

### 変更内容

- `button.tsx`: `Size` 型に `'x-large'` を追加、`h-12 px-4 leading-[24px]` のクラスマッピングを追加
- `button.test.tsx`: x-large サイズのテストケースを追加
- `button.stories.tsx`: x-large をコントロールと Base ストーリーに追加（全4バリアント）
- `button-specification.md`: 仕様書に x-large セクション・Props 型・更新履歴を追加

### 影響範囲

- FileInput / DatePicker: 独自の Size 型を持ち Button の型を import していないため影響なし
- IconButton: 独立実装で Figma にも x-large 未定義のため影響なし

## 実行したコマンド

```bash
yarn type-check    # 通過
yarn lint          # 通過（変更ファイルのみ確認）
yarn test          # 全 417 件通過（新規テスト含む）
```