### PR TITLE
Refactor TextInput stories by variant for Chromatic optimization

### DIFF
--- a/packages/component-ui/src/text-input/Docs.mdx
+++ b/packages/component-ui/src/text-input/Docs.mdx
@@ -1,6 +1,6 @@
 import { Canvas, Meta, ArgTypes, Story, Controls, Source } from '@storybook/addon-docs/blocks';
 import { Markdown } from '@storybook/addon-docs/blocks';
-import TextInputStories, { Component, Base } from './text-input.stories';
+import TextInputStories, { Component } from './text-input.stories';
 import spec from '../../../../docs/component/text-input-specification.md?raw';
 
 <Meta title="TextInput" of={TextInputStories} />

--- a/packages/component-ui/src/text-input/text-input.stories.tsx
+++ b/packages/component-ui/src/text-input/text-input.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import clsx from 'clsx';
-import type { ChangeEvent, ReactNode } from 'react';
+import type { ChangeEvent } from 'react';
 import { useState } from 'react';
 import { action } from 'storybook/actions';
 
@@ -53,517 +52,170 @@ export const Component: Story = {
   },
 };
 
-type ErrorTextProps = {
-  children?: ReactNode;
-  isError?: boolean;
-};
-
-const ErrorText = ({ isError = false, ...props }: ErrorTextProps) => {
-  const classes = clsx('typography-label11regular mt-1 px-2', {
-    'text-text02': !isError,
-    'text-supportError': isError,
-  });
-
-  return <div className={classes}>{props.children}</div>;
-};
-
-export const Base: Story = {
-  args: {
-    value: '',
-  },
-  render: function MyFunc({ ...args }) {
-    const [value, setValue] = useState<string>(args.value);
-    const [value2, setValue2] = useState<string>(
-      '入力文字列入力文字列入力文字列入力文字列入力文字列入力文字列入力文字列入力文字列',
-    );
-    const [valueNumber, setValueNumber] = useState<string>('123');
-    const [valuePassword, setValuePassword] = useState<string>('abcdefg');
-
-    return (
-      <div className="flex gap-10">
-        {/* サイズ：medium */}
-        <div style={{ width: 300 }} className="flex flex-col gap-12">
-          <div>
-            <TextInput
-              value={value}
-              placeholder="入力してください"
-              size="medium"
-              onChange={(e: ChangeEvent<HTMLInputElement>) => {
-                action('onChange')(e);
-                setValue(e.target.value);
-              }}
-              onClickClearButton={() => {
-                setValue('');
-              }}
-            />
-            <ErrorText>文字以内で入力してください</ErrorText>
-          </div>
-          <div>
-            <TextInput
-              value={value}
-              placeholder="入力してください"
-              size="medium"
-              isError
-              onChange={(e: ChangeEvent<HTMLInputElement>) => {
-                action('onChange')(e);
-                setValue(e.target.value);
-              }}
-              onClickClearButton={() => {
-                setValue('');
-              }}
-            />
-            <ErrorText isError>文字以内で入力してください</ErrorText>
-          </div>
-          <div>
-            <TextInput
-              value={value2}
-              placeholder="入力してください"
-              size="medium"
-              isError
-              onChange={(e: ChangeEvent<HTMLInputElement>) => {
-                action('onChange')(e);
-                setValue2(e.target.value);
-              }}
-              onClickClearButton={() => {
-                setValue2('');
-              }}
-            />
-            <ErrorText isError>文字以内で入力してください</ErrorText>
-          </div>
-          <div>
-            <TextInput
-              value={value}
-              placeholder="入力してください"
-              size="medium"
-              onChange={(e: ChangeEvent<HTMLInputElement>) => {
-                action('onChange')(e);
-                setValue(e.target.value);
-              }}
-              onClickClearButton={() => {
-                setValue('');
-              }}
-              disabled
-            />
-          </div>
-          <div>
-            <TextInput
-              value={value2}
-              placeholder="入力してください"
-              size="medium"
-              disabled
-              onChange={(e: ChangeEvent<HTMLInputElement>) => {
-                action('onChange')(e);
-                setValue2(e.target.value);
-              }}
-              onClickClearButton={() => {
-                setValue2('');
-              }}
-            />
-          </div>
-          <div>
-            <TextInput
-              value={valueNumber}
-              placeholder="入力してください"
-              size="medium"
-              onChange={(e: ChangeEvent<HTMLInputElement>) => {
-                action('onChange')(e);
-                setValueNumber(e.target.value);
-              }}
-              type="number"
-            />
-          </div>
-          <div>
-            <TextInput
-              value={valuePassword}
-              placeholder="入力してください"
-              size="medium"
-              onChange={(e: ChangeEvent<HTMLInputElement>) => {
-                action('onChange')(e);
-                setValuePassword(e.target.value);
-              }}
-              onClickClearButton={() => {
-                setValuePassword('');
-              }}
-              type="password"
-            />
-          </div>
-          <div>
-            <TextInput
-              value={value}
-              placeholder="入力してください"
-              size="medium"
-              onChange={(e: ChangeEvent<HTMLInputElement>) => {
-                action('onChange')(e);
-                setValue(e.target.value);
-              }}
-            />
-            <ErrorText>クリアボタンなし</ErrorText>
-          </div>
+export const Outline: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4">
+      {/* デフォルト */}
+      <div className="flex gap-4">
+        <div className="w-[300px]">
+          <TextInput value="" placeholder="入力してください" size="medium" readOnly />
         </div>
-        {/* サイズ：large */}
-        <div style={{ width: 300 }} className="flex flex-col gap-10">
-          <div>
-            <TextInput
-              value={value}
-              placeholder="入力してください"
-              size="large"
-              onChange={(e: ChangeEvent<HTMLInputElement>) => {
-                action('onChange')(e);
-                setValue(e.target.value);
-              }}
-              onClickClearButton={() => {
-                setValue('');
-              }}
-            />
-            <ErrorText>文字以内で入力してください</ErrorText>
-          </div>
-          <div>
-            <TextInput
-              value={value}
-              placeholder="入力してください"
-              size="large"
-              isError
-              onChange={(e: ChangeEvent<HTMLInputElement>) => {
-                action('onChange')(e);
-                setValue(e.target.value);
-              }}
-              onClickClearButton={() => {
-                setValue('');
-              }}
-            />
-            <ErrorText isError>文字以内で入力してください</ErrorText>
-          </div>
-          <div>
-            <TextInput
-              value={value2}
-              placeholder="入力してください"
-              size="large"
-              isError
-              onChange={(e: ChangeEvent<HTMLInputElement>) => {
-                action('onChange')(e);
-                setValue2(e.target.value);
-              }}
-              onClickClearButton={() => {
-                setValue2('');
-              }}
-            />
-            <ErrorText isError>文字以内で入力してください</ErrorText>
-          </div>
-          <div>
-            <TextInput
-              value=""
-              placeholder="入力してください"
-              size="large"
-              isError
-              onChange={(e: ChangeEvent<HTMLInputElement>) => {
-                action('onChange')(e);
-                setValue2(e.target.value);
-              }}
-              onClickClearButton={() => {
-                setValue2('');
-              }}
-              disabled
-            />
-          </div>
-          <div>
-            <TextInput
-              value={value2}
-              placeholder="入力してください"
-              size="large"
-              disabled
-              onChange={(e: ChangeEvent<HTMLInputElement>) => {
-                action('onChange')(e);
-                setValue(e.target.value);
-              }}
-              onClickClearButton={() => {
-                setValue('');
-              }}
-            />
-          </div>
-          <div>
-            <TextInput
-              value={valueNumber}
-              placeholder="入力してください"
-              size="large"
-              onChange={(e: ChangeEvent<HTMLInputElement>) => {
-                action('onChange')(e);
-                setValueNumber(e.target.value);
-              }}
-              type="number"
-            />
-          </div>
-          <div>
-            <TextInput
-              value={valuePassword}
-              placeholder="入力してください"
-              size="large"
-              onChange={(e: ChangeEvent<HTMLInputElement>) => {
-                action('onChange')(e);
-                setValuePassword(e.target.value);
-              }}
-              onClickClearButton={() => {
-                setValuePassword('');
-              }}
-              type="password"
-            />
-          </div>
-          <div>
-            <TextInput
-              value={value}
-              placeholder="入力してください"
-              size="large"
-              onChange={(e: ChangeEvent<HTMLInputElement>) => {
-                action('onChange')(e);
-                setValue(e.target.value);
-              }}
-            />
-            <ErrorText>クリアボタンなし</ErrorText>
-          </div>
+        <div className="w-[300px]">
+          <TextInput value="入力文字列" size="medium" readOnly onClickClearButton={() => {}} />
+        </div>
+        <div className="w-[300px]">
+          <TextInput value="入力文字列" size="medium" readOnly />
         </div>
       </div>
-    );
-  },
+      <div className="flex gap-4">
+        <div className="w-[300px]">
+          <TextInput value="" placeholder="入力してください" size="large" readOnly />
+        </div>
+        <div className="w-[300px]">
+          <TextInput value="入力文字列" size="large" readOnly onClickClearButton={() => {}} />
+        </div>
+        <div className="w-[300px]">
+          <TextInput value="入力文字列" size="large" readOnly />
+        </div>
+      </div>
+      {/* エラー */}
+      <div className="flex gap-4">
+        <div className="w-[300px]">
+          <TextInput value="" placeholder="入力してください" size="medium" isError readOnly>
+            <TextInput.ErrorMessage>入力内容にエラーがあります</TextInput.ErrorMessage>
+          </TextInput>
+        </div>
+        <div className="w-[300px]">
+          <TextInput value="入力文字列" size="medium" isError readOnly onClickClearButton={() => {}}>
+            <TextInput.ErrorMessage>入力内容にエラーがあります</TextInput.ErrorMessage>
+          </TextInput>
+        </div>
+      </div>
+      <div className="flex gap-4">
+        <div className="w-[300px]">
+          <TextInput value="" placeholder="入力してください" size="large" isError readOnly>
+            <TextInput.ErrorMessage>入力内容にエラーがあります</TextInput.ErrorMessage>
+          </TextInput>
+        </div>
+        <div className="w-[300px]">
+          <TextInput value="入力文字列" size="large" isError readOnly onClickClearButton={() => {}}>
+            <TextInput.ErrorMessage>入力内容にエラーがあります</TextInput.ErrorMessage>
+          </TextInput>
+        </div>
+      </div>
+      {/* 無効 */}
+      <div className="flex gap-4">
+        <div className="w-[300px]">
+          <TextInput value="" placeholder="入力してください" size="medium" disabled />
+        </div>
+        <div className="w-[300px]">
+          <TextInput value="入力文字列" size="medium" disabled />
+        </div>
+        <div className="w-[300px]">
+          <TextInput value="" placeholder="入力してください" size="medium" disabled isError />
+        </div>
+      </div>
+      <div className="flex gap-4">
+        <div className="w-[300px]">
+          <TextInput value="" placeholder="入力してください" size="large" disabled />
+        </div>
+        <div className="w-[300px]">
+          <TextInput value="入力文字列" size="large" disabled />
+        </div>
+        <div className="w-[300px]">
+          <TextInput value="" placeholder="入力してください" size="large" disabled isError />
+        </div>
+      </div>
+      {/* type バリエーション */}
+      <div className="flex gap-4">
+        <div className="w-[300px]">
+          <TextInput value="123" size="medium" type="number" readOnly />
+        </div>
+        <div className="w-[300px]">
+          <TextInput value="abcdefg" size="medium" type="password" readOnly onClickClearButton={() => {}} />
+        </div>
+      </div>
+      <div className="flex gap-4">
+        <div className="w-[300px]">
+          <TextInput value="123" size="large" type="number" readOnly />
+        </div>
+        <div className="w-[300px]">
+          <TextInput value="abcdefg" size="large" type="password" readOnly onClickClearButton={() => {}} />
+        </div>
+      </div>
+    </div>
+  ),
+};
+
+export const WithMessages: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4">
+      <div className="flex gap-4">
+        <div className="w-[300px]">
+          <TextInput value="" placeholder="入力してください" size="medium" readOnly>
+            <TextInput.HelperMessage>○文字以内で入力してください</TextInput.HelperMessage>
+          </TextInput>
+        </div>
+        <div className="w-[300px]">
+          <TextInput value="" placeholder="入力してください" size="medium" isError readOnly>
+            <TextInput.HelperMessage>○文字以内で入力してください</TextInput.HelperMessage>
+            <TextInput.ErrorMessage>入力内容にエラーがあります</TextInput.ErrorMessage>
+          </TextInput>
+        </div>
+        <div className="w-[300px]">
+          <TextInput value="" placeholder="入力してください" size="medium" isError readOnly>
+            <TextInput.ErrorMessage>
+              入力内容にエラーがあります 入力内容にエラーがあります 入力内容にエラーがあります
+            </TextInput.ErrorMessage>
+            <TextInput.ErrorMessage>入力内容にエラーがあります</TextInput.ErrorMessage>
+          </TextInput>
+        </div>
+        <div className="w-[300px]">
+          <TextInput value="" placeholder="入力してください" size="medium" readOnly>
+            <TextInput.HelperMessage>
+              ○文字以内で入力してください ○文字以内で入力してください ○文字以内で入力してください
+            </TextInput.HelperMessage>
+            <TextInput.HelperMessage>○文字以内で入力してください</TextInput.HelperMessage>
+          </TextInput>
+        </div>
+      </div>
+      <div className="flex gap-4">
+        <div className="w-[300px]">
+          <TextInput value="" placeholder="入力してください" size="large" readOnly>
+            <TextInput.HelperMessage>○文字以内で入力してください</TextInput.HelperMessage>
+          </TextInput>
+        </div>
+        <div className="w-[300px]">
+          <TextInput value="" placeholder="入力してください" size="large" isError readOnly>
+            <TextInput.HelperMessage>○文字以内で入力してください</TextInput.HelperMessage>
+            <TextInput.ErrorMessage>入力内容にエラーがあります</TextInput.ErrorMessage>
+          </TextInput>
+        </div>
+        <div className="w-[300px]">
+          <TextInput value="" placeholder="入力してください" size="large" isError readOnly>
+            <TextInput.ErrorMessage>
+              入力内容にエラーがあります 入力内容にエラーがあります 入力内容にエラーがあります
+            </TextInput.ErrorMessage>
+            <TextInput.ErrorMessage>入力内容にエラーがあります</TextInput.ErrorMessage>
+          </TextInput>
+        </div>
+        <div className="w-[300px]">
+          <TextInput value="" placeholder="入力してください" size="large" readOnly>
+            <TextInput.HelperMessage>
+              ○文字以内で入力してください ○文字以内で入力してください ○文字以内で入力してください
+            </TextInput.HelperMessage>
+            <TextInput.HelperMessage>○文字以内で入力してください</TextInput.HelperMessage>
+          </TextInput>
+        </div>
+      </div>
+    </div>
+  ),
 };
 
 export const Focused: Story = {
-  args: {
-    value: '',
-  },
-  render: function FocusedStory({ ...args }) {
-    const [value, setValue] = useState<string>(args.value);
-
-    return (
-      <div style={{ width: 300 }}>
-        <TextInput
-          value={value}
-          placeholder="フォーカス状態"
-          size="medium"
-          autoFocus
-          onChange={(e: ChangeEvent<HTMLInputElement>) => {
-            setValue(e.target.value);
-          }}
-          onClickClearButton={() => {
-            setValue('');
-          }}
-        />
-      </div>
-    );
-  },
-};
-
-export const Composition: Story = {
-  render: function CompositionStory() {
-    const [value, setValue] = useState<string>('');
-    const [value2, setValue2] = useState<string>(
-      '入力文字列入力文字列入力文字列入力文字列入力文字列入力文字列入力文字列入力文字列',
-    );
-    const [valueNumber, setValueNumber] = useState<string>('123');
-
-    const handleChange = (setter: (nextValue: string) => void) => (event: ChangeEvent<HTMLInputElement>) => {
-      action('onChange')(event);
-      setter(event.target.value);
-    };
-
-    const handleClear = (setter: (nextValue: string) => void) => () => {
-      action('onClickClearButton')();
-      setter('');
-    };
-
-    const classNameLine = 'flex w-[300px] flex-col gap-12';
-    const classNameCell = 'h-[52px]';
-    const classNameCellS = 'h-[32px]';
-
-    return (
-      <div className="flex gap-10">
-        <div className={classNameLine}>
-          <div className={classNameCell}>
-            <TextInput
-              value={value}
-              placeholder="入力してください"
-              size="medium"
-              onChange={handleChange(setValue)}
-              onClickClearButton={handleClear(setValue)}
-            >
-              <TextInput.HelperMessage>○文字以内で入力してください</TextInput.HelperMessage>
-            </TextInput>
-          </div>
-          <div className={classNameCell}>
-            <TextInput
-              value={value}
-              placeholder="入力してください"
-              size="medium"
-              onChange={handleChange(setValue)}
-              onClickClearButton={handleClear(setValue)}
-            >
-              <TextInput.HelperMessage>
-                ○文字以内で入力してください ○文字以内で入力してください ○文字以内で入力してください
-              </TextInput.HelperMessage>
-              <TextInput.HelperMessage>○文字以内で入力してください</TextInput.HelperMessage>
-            </TextInput>
-          </div>
-          <div className={classNameCell}>
-            <TextInput
-              value={value}
-              placeholder="入力してください"
-              size="medium"
-              isError
-              onChange={handleChange(setValue)}
-              onClickClearButton={handleClear(setValue)}
-            >
-              <TextInput.HelperMessage>○文字以内で入力してください</TextInput.HelperMessage>
-              <TextInput.ErrorMessage>入力内容にエラーがあります</TextInput.ErrorMessage>
-            </TextInput>
-          </div>
-          <div className={classNameCell}>
-            <TextInput
-              value={value}
-              placeholder="入力してください"
-              size="medium"
-              isError
-              onChange={handleChange(setValue)}
-              onClickClearButton={handleClear(setValue)}
-            >
-              <TextInput.ErrorMessage>
-                入力内容にエラーがあります 入力内容にエラーがあります 入力内容にエラーがあります
-              </TextInput.ErrorMessage>
-              <TextInput.ErrorMessage>入力内容にエラーがあります</TextInput.ErrorMessage>
-            </TextInput>
-          </div>
-          <div className={classNameCell}>
-            <TextInput
-              value={value2}
-              placeholder="入力してください"
-              size="medium"
-              isError
-              onChange={handleChange(setValue2)}
-              onClickClearButton={handleClear(setValue2)}
-            />
-          </div>
-          <div className={classNameCellS}>
-            <TextInput
-              value={value}
-              placeholder="入力してください"
-              size="medium"
-              disabled
-              onChange={handleChange(setValue)}
-              onClickClearButton={handleClear(setValue)}
-            />
-          </div>
-          <div className={classNameCellS}>
-            <TextInput
-              value={value2}
-              placeholder="入力してください"
-              size="medium"
-              disabled
-              onChange={handleChange(setValue2)}
-              onClickClearButton={handleClear(setValue2)}
-            />
-          </div>
-          <div className={classNameCellS}>
-            <TextInput
-              value={valueNumber}
-              placeholder="入力してください"
-              size="medium"
-              type="number"
-              onChange={handleChange(setValueNumber)}
-            />
-          </div>
-        </div>
-        <div className={classNameLine}>
-          <div className={classNameCell}>
-            <TextInput
-              value={value}
-              placeholder="入力してください"
-              size="large"
-              onChange={handleChange(setValue)}
-              onClickClearButton={handleClear(setValue)}
-            >
-              <TextInput.HelperMessage>○文字以内で入力してください</TextInput.HelperMessage>
-            </TextInput>
-          </div>
-          <div className={classNameCell}>
-            <TextInput
-              value={value}
-              placeholder="入力してください"
-              size="large"
-              onChange={handleChange(setValue)}
-              onClickClearButton={handleClear(setValue)}
-            >
-              <TextInput.HelperMessage>
-                ○文字以内で入力してください ○文字以内で入力してください ○文字以内で入力してください
-              </TextInput.HelperMessage>
-              <TextInput.HelperMessage>○文字以内で入力してください</TextInput.HelperMessage>
-            </TextInput>
-          </div>
-          <div className={classNameCell}>
-            <TextInput
-              value={value}
-              placeholder="入力してください"
-              size="large"
-              isError
-              onChange={handleChange(setValue)}
-              onClickClearButton={handleClear(setValue)}
-            >
-              <TextInput.HelperMessage>○文字以内で入力してください</TextInput.HelperMessage>
-              <TextInput.ErrorMessage>入力内容にエラーがあります</TextInput.ErrorMessage>
-            </TextInput>
-          </div>
-          <div className={classNameCell}>
-            <TextInput
-              value={value}
-              placeholder="入力してください"
-              size="large"
-              isError
-              onChange={handleChange(setValue)}
-              onClickClearButton={handleClear(setValue)}
-            >
-              <TextInput.ErrorMessage>
-                入力内容にエラーがあります 入力内容にエラーがあります 入力内容にエラーがあります
-              </TextInput.ErrorMessage>
-              <TextInput.ErrorMessage>入力内容にエラーがあります</TextInput.ErrorMessage>
-            </TextInput>
-          </div>
-          <div className={classNameCell}>
-            <TextInput
-              value={value2}
-              placeholder="入力してください"
-              size="large"
-              isError
-              onChange={handleChange(setValue2)}
-              onClickClearButton={handleClear(setValue2)}
-            />
-          </div>
-          <div className={classNameCellS}>
-            <TextInput
-              value={value}
-              placeholder="入力してください"
-              size="large"
-              disabled
-              onChange={handleChange(setValue)}
-              onClickClearButton={handleClear(setValue)}
-            />
-          </div>
-          <div className={classNameCellS}>
-            <TextInput
-              value={value2}
-              placeholder="入力してください"
-              size="large"
-              disabled
-              onChange={handleChange(setValue2)}
-              onClickClearButton={handleClear(setValue2)}
-            />
-          </div>
-          <div className={classNameCellS}>
-            <TextInput
-              value={valueNumber}
-              placeholder="入力してください"
-              size="large"
-              type="number"
-              onChange={handleChange(setValueNumber)}
-            />
-          </div>
-        </div>
-      </div>
-    );
-  },
+  render: () => (
+    <div className="w-[300px]">
+      <TextInput value="" placeholder="フォーカス状態" size="medium" autoFocus readOnly />
+    </div>
+  ),
 };


### PR DESCRIPTION
> [!NOTE]
> - https://github.com/zenkigen/zenkigen-component/pull/548 が先にマージされてからの作業が良さそう 

## 概要

TextInput の Stories を Storybook ガイドライン（`docs/storybook-guidelines.md`）に準拠した形にリファクタリング。

### 変更内容

- `Base` Story（全状態を1つに詰め込み + useState + action）を variant ベースの `Outline` Story に再構成
- `Composition` Story を `WithMessages` Story に再構成（Compound Component パターンの組み合わせ）
- `Focused` Story を簡素化（autoFocus + readOnly）
- 独自 `ErrorText` ヘルパーコンポーネントを削除し、`TextInput.ErrorMessage` / `TextInput.HelperMessage` を使用
- render 固定型 + `readOnly` パターンで VRT 向けに最適化（569行 → 約210行）
- `disabled && isError` の掛け合わせ状態をカバー
- `Docs.mdx` から `Base` の import を削除

### Story 構成

| Story | 内容 | Chromatic |
|-------|------|-----------|
| `Component` | args 駆動（Controls 用） | disable |
| `Outline` | 全状態（default / error / disabled+isError / number / password）× medium / large | 対象 |
| `WithMessages` | HelperMessage / ErrorMessage の組み合わせ × medium / large | 対象 |
| `Focused` | autoFocus 状態 | 対象 |

### 関連 PR

- #560 `refactor/button-stories-split-by-variant`（ベースブランチ）

### 備考

- TextInput に `text` variant が追加される予定のため、variant ベースの構造を採用。`text` variant 合流時は `Text` Story を追加するだけで対応可能
