### PR TITLE
refactor(Storybook:radio): split stories by state for Chromatic optimization

### DIFF
--- a/packages/component-ui/src/radio/radio.stories.tsx
+++ b/packages/component-ui/src/radio/radio.stories.tsx
@@ -1,6 +1,4 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import type { ChangeEvent } from 'react';
-import { useCallback, useState } from 'react';
 
 import { Radio } from '.';
 
@@ -14,70 +12,43 @@ type Story = StoryObj<typeof Radio>;
 
 export const Component: Story = {
   args: {
-    label: 'label',
+    label: 'ラベル',
     isChecked: false,
     isDisabled: false,
-    name: 'name',
+    name: 'radio-component',
     value: 'value',
-    id: 'id',
+    id: 'radio-component',
   },
   parameters: {
     chromatic: { disable: true },
   },
 };
 
-export function Base() {
-  const [selectedValue, setSelectedValue] = useState('');
-
-  const handleChange = useCallback(
-    ({ target: { value } }: ChangeEvent<HTMLInputElement>) => setSelectedValue(value),
-    [],
-  );
-
-  return (
-    <ul>
-      <div className="mb-6">
-        <Radio
-          id="1"
-          name="radio-group"
-          label="Radio button 1"
-          value="foo"
-          onChange={handleChange}
-          isChecked={selectedValue === 'foo'}
-        />
+export const Default: Story = {
+  render: () => (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center gap-4">
+        <Radio id="default-unchecked" name="default-group" label="未選択" value="unchecked" />
+        <Radio id="default-checked" name="default-checked" label="選択済み" value="checked" isChecked />
       </div>
-      <div className="mb-6">
+    </div>
+  ),
+};
+
+export const Disabled: Story = {
+  render: () => (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center gap-4">
+        <Radio id="disabled-unchecked" name="disabled-group" label="無効（未選択）" value="unchecked" isDisabled />
         <Radio
-          id="2"
-          name="radio-group"
-          label="Radio button 2"
-          value="bar"
-          onChange={handleChange}
-          isChecked={selectedValue === 'bar'}
-        />
-      </div>
-      <div className="mb-6">
-        <Radio
-          id="1"
-          name="radio-group"
-          label="Radio button 1"
-          value="foo"
-          onChange={handleChange}
-          isChecked={selectedValue === 'foo'}
+          id="disabled-checked"
+          name="disabled-checked"
+          label="無効（選択済み）"
+          value="checked"
+          isChecked
           isDisabled
         />
       </div>
-      <div className="mb-6">
-        <Radio
-          id="2"
-          name="radio-group"
-          label="Radio button 2"
-          value="bar"
-          onChange={handleChange}
-          isChecked={selectedValue === 'bar'}
-          isDisabled
-        />
-      </div>
-    </ul>
-  );
-}
+    </div>
+  ),
+};


### PR DESCRIPTION
> [!NOTE]
> - Storybook の 改善タスク
>  - 実装コードの変更なし

## 概要

Radio コンポーネントの Storybook Story をリファクタリング。

### 変更内容

- CSF2 の `Base` function export を削除し、CSF3 `StoryObj` 形式の `Default` / `Disabled` Story に分割
- `mb-6` マージン → `flex flex-col gap-*` レイアウトに変更
- 不正な HTML 構造（`<ul>` 内に `<li>` なし）、ID 重複を解消
- ラベルを日本語に統一
- `Component` Story は args 駆動 + `chromatic: { disable: true }` を維持

### Story 構成

| Story | 種類 | Chromatic | 内容 |
|-------|------|-----------|------|
| `Component` | args 駆動 | disable | Controls 操作用 |
| `Default` | render 固定 | 対象 | unchecked + checked |
| `Disabled` | render 固定 | 対象 | disabled unchecked + disabled checked |

### 今後の拡張

size バリエーション追加時は、各 Story の末尾に行を追加するだけで既存の Chromatic スナップショットへの影響を最小化できる構造。

## テストプラン

- [ ] `yarn lint` パス確認済み
- [ ] `yarn type-check` パス確認済み
- [ ] Storybook で Component / Default / Disabled の各 Story が正しく表示されること
- [ ] Chromatic で Default / Disabled のスナップショットが取得されること