### PR TITLE
refactor(Storybook:checkbox): split stories by color for Chromatic optimization

### DIFF
--- a/packages/component-ui/src/checkbox/checkbox.stories.tsx
+++ b/packages/component-ui/src/checkbox/checkbox.stories.tsx
@@ -1,11 +1,16 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { useCallback, useState } from 'react';
 
 import { Checkbox } from './checkbox';
 
 const meta: Meta<typeof Checkbox> = {
   title: 'Components/Checkbox',
   component: Checkbox,
+  argTypes: {
+    color: {
+      options: ['default', 'gray', 'error'],
+      control: { type: 'radio' },
+    },
+  },
 };
 
 export default meta;
@@ -13,89 +18,62 @@ type Story = StoryObj<typeof Checkbox>;
 
 export const Component: Story = {
   args: {
-    label: 'label',
+    label: 'ラベル',
     color: 'default',
     isChecked: false,
     isIndeterminate: false,
     isDisabled: false,
-    id: '1',
+    id: 'checkbox-component',
   },
   parameters: {
     chromatic: { disable: true },
   },
 };
 
-export function Base() {
-  const [isCheck, setCheck] = useState(false);
-
-  const [isIndeterminate, setIndeterminate] = useState(false);
-
-  const handleCheckbox = useCallback(() => {
-    setCheck((state) => !state);
-  }, []);
-
-  const handleIndeterminateCheckbox = useCallback(() => {
-    setIndeterminate((state) => !state);
-  }, []);
-
-  return (
-    <div className="flex flex-col gap-6">
-      <div className="flex gap-10">
-        <Checkbox
-          id="1"
-          label="Checkbox"
-          onChange={handleCheckbox}
-          isIndeterminate={isIndeterminate}
-          isChecked={isCheck}
-          color="default"
-        />
-
-        <Checkbox
-          id="2"
-          label="Switch to indeterminate"
-          onChange={handleIndeterminateCheckbox}
-          isChecked={isIndeterminate}
-          color="default"
-        />
-      </div>
-
-      <div className="flex flex-col gap-2">
-        <div className="flex gap-10">
-          <Checkbox id="1" label="Checkbox" />
-          <Checkbox id="1" label="Checkbox" isChecked />
-          <Checkbox id="2" label="Checkbox" isChecked isIndeterminate />
-        </div>
-      </div>
-
-      <div className="flex flex-col gap-2">
-        <div className="flex gap-10">
-          <Checkbox id="1" label="Checkbox" color="gray" />
-          <Checkbox id="1" label="Checkbox" isChecked color="gray" />
-          <Checkbox id="2" label="Checkbox" isChecked isIndeterminate color="gray" />
-        </div>
-      </div>
-
-      <div className="flex flex-col gap-2">
-        <div className="flex gap-10">
-          <Checkbox id="1" label="Checkbox" color="error" />
-          <Checkbox id="1" label="Checkbox" isChecked color="error" />
-          <Checkbox id="2" label="Checkbox" isChecked isIndeterminate color="error" />
-        </div>
-      </div>
-
-      <div className="flex flex-col gap-2">
-        <div className="flex gap-10">
-          <Checkbox id="1" label="Checkbox" isDisabled />
-          <Checkbox id="1" label="Checkbox" isChecked isDisabled />
-          <Checkbox id="2" label="Checkbox" isChecked isIndeterminate isDisabled />
-        </div>
-      </div>
-
-      <div className="flex gap-10">
-        <Checkbox />
-        <Checkbox isChecked />
-        <Checkbox isChecked isIndeterminate />
+export const Default: Story = {
+  render: () => (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center gap-4">
+        <Checkbox id="default-unchecked" label="未選択" color="default" />
+        <Checkbox id="default-checked" label="選択済み" color="default" isChecked />
+        <Checkbox id="default-indeterminate" label="インデターミネイト" color="default" isChecked isIndeterminate />
       </div>
     </div>
-  );
-}
+  ),
+};
+
+export const Gray: Story = {
+  render: () => (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center gap-4">
+        <Checkbox id="gray-unchecked" label="未選択" color="gray" />
+        <Checkbox id="gray-checked" label="選択済み" color="gray" isChecked />
+        <Checkbox id="gray-indeterminate" label="インデターミネイト" color="gray" isChecked isIndeterminate />
+      </div>
+    </div>
+  ),
+};
+
+export const Error: Story = {
+  render: () => (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center gap-4">
+        <Checkbox id="error-unchecked" label="未選択" color="error" />
+        <Checkbox id="error-checked" label="選択済み" color="error" isChecked />
+        <Checkbox id="error-indeterminate" label="インデターミネイト" color="error" isChecked isIndeterminate />
+      </div>
+    </div>
+  ),
+};
+
+export const Disabled: Story = {
+  render: () => (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center gap-4">
+        <Checkbox id="disabled-unchecked" label="無効(未選択)" isDisabled />
+        <Checkbox id="disabled-checked" label="無効(選択済み)" isDisabled isChecked />
+        <Checkbox id="disabled-indeterminate" label="無効(インデターミネイト)" isDisabled isChecked isIndeterminate />
+      </div>
+    </div>
+  ),
+};


### PR DESCRIPTION
> [!NOTE]
> - Storybook の 改善タスク
>  - 実装コードの変更なし

## 概要

Checkbox の Storybook を Button / TextInput / Radio と同じ方針で `color` 軸に分割し、Chromatic のビジュアルリグレッション差分の影響範囲を最小化する。

## 変更点

- 既存の `Base` Story(全バリエーション詰め込み、`id` 重複、`flex gap-10` レイアウト)を廃止
- `Component` — args 駆動 + `color` の `argTypes`(radio control)、`chromatic: { disable: true }`
- `Default` / `Gray` / `Error` — 各 `color` ごとの Story。列 = [未選択 / 選択済み / インデターミネイト]
- `Disabled` — 独立 Story。`isDisabled=true` のとき全 color が `disabled01` 系に上書きされ視覚差が消えるため集約(詳細は改訂後の Storybook ガイドライン「状態によって主要軸が視覚的に潰れる場合」参照)
- 将来の `size: 'medium' | 'large'` 追加を見据えて各 render 固定 Story を外側 `flex flex-col gap-2` / 内側 `flex items-center gap-4` の「行 = size、列 = 状態」枠組みで構成。size 追加時は末尾行を足すだけで済む
- `id` を `default-*` / `gray-*` / `error-*` / `disabled-*` の接頭辞付きで一意化し、既存 Base の `id='1'` / `id='2'` 重複問題を解消
- ラベル文字列は「未選択」「選択済み」「インデターミネイト」等の実用的な日本語に統一

## 参考

- Story 分割方針は Button PR #560 および改訂後の `docs/storybook-guidelines.md` に準拠
- 将来 `size` prop 追加を別 PR で行う想定。Radio の `feat/radio-size-large` ブランチが先行事例

## PR の依存関係

本 PR は #560 (`refactor(Storybook:button): split stories by variant`) を base にした **stacked PR** です。改訂後の Storybook ガイドライン(state 管理型サンプル修正、分割パターン拡充)は #560 側のブランチ `refactor/button-stories-split-by-variant` に含まれます。

## 実行したコマンド

- \`yarn type-check\` ✅
- \`yarn eslint 'packages/component-ui/src/checkbox/**/*.ts{,x}'\` ✅
- \`yarn prettier --check 'packages/component-ui/src/checkbox/**/*.tsx'\` ✅

## Test plan

- [ ] \`yarn storybook\` で \`Components/Checkbox\` 配下に 5 Story (\`Component\` / \`Default\` / \`Gray\` / \`Error\` / \`Disabled\`) が並ぶこと
- [ ] \`Component\` Story の Controls パネルで \`color\` が radio で切り替わり、\`isChecked\` / \`isIndeterminate\` / \`isDisabled\` / \`label\` が操作できること
- [ ] \`Component\` Story のみ Chromatic disable (Docs タブの parameters で確認)
- [ ] \`Default\` / \`Gray\` / \`Error\` それぞれで未選択 / 選択済み / インデターミネイトが 3 列で並ぶこと
- [ ] \`Disabled\` で 3 状態が並び、全て \`disabled01\` 系の淡色表示になっていること
- [ ] Chromatic のビジュアルリグレッション差分が想定通り(既存 Base 削除 + 新規 4 Story 追加)であること