### PR TITLE
refactor(Storybook:tag): split stories by color category for Chromatic optimization

### DIFF
--- a/packages/component-ui/src/tag/tag.stories.tsx
+++ b/packages/component-ui/src/tag/tag.stories.tsx
@@ -61,21 +61,28 @@ export const Component: Story = {
   args: {
     size: 'medium',
     variant: 'normal',
-    children: 'タグラベル',
+    children: '重要',
     color: 'default',
-    id: '1',
+    id: 'component',
   },
   parameters: {
     chromatic: { disable: true },
   },
   render: ({ onDelete, isEditable, size, ...rest }) => {
     const handleDelete = onDelete ?? action('tag削除');
-    const displaySize = isEditable ? 'medium' : size;
+    const displaySize = isEditable === true ? 'medium' : size;
 
     return (
       <div className="flex items-center justify-center gap-x-4">
-        {typeof isEditable === 'undefined' && <Tag {...rest} size={displaySize} />}
-        <Tag variant={rest.variant} color={rest.color} size="medium" id="2" isEditable onDelete={handleDelete}>
+        {isEditable !== true && <Tag {...rest} size={displaySize} />}
+        <Tag
+          variant={rest.variant}
+          color={rest.color}
+          size="medium"
+          id="component-editable"
+          isEditable
+          onDelete={handleDelete}
+        >
           {rest.children}
         </Tag>
       </div>
@@ -83,576 +90,528 @@ export const Component: Story = {
   },
 };
 
-export function Basic() {
-  return (
-    <>
-      <h2 className="mb-1 text-gray-gray50">Support</h2>
-      <div className="flex items-center gap-x-5">
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="1" color="supportError" size="medium">
-            タグラベル
+export const Support: Story = {
+  render: () => (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center gap-2">
+          <Tag id="support-error-xs" color="supportError" size="x-small">
+            エラー
           </Tag>
-          <Tag id="1" color="supportError" size="small">
-            タグラベル
+          <Tag id="support-success-xs" color="supportSuccess" size="x-small">
+            成功
           </Tag>
-          <Tag id="1" color="supportError" size="x-small">
-            タグラベル
+          <Tag id="support-warning-xs" color="supportWarning" size="x-small">
+            警告
           </Tag>
-        </div>
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="2" color="supportSuccess" size="medium">
-            タグラベル
-          </Tag>
-          <Tag id="2" color="supportSuccess" size="small">
-            タグラベル
-          </Tag>
-          <Tag id="2" color="supportSuccess" size="x-small">
-            タグラベル
+          <Tag id="support-danger-xs" color="supportDanger" size="x-small">
+            危険
           </Tag>
         </div>
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="3" color="supportWarning" size="medium">
-            タグラベル
+        <div className="flex items-center gap-2">
+          <Tag id="support-error-sm" color="supportError" size="small">
+            エラー
           </Tag>
-          <Tag id="3" color="supportWarning" size="small">
-            タグラベル
+          <Tag id="support-success-sm" color="supportSuccess" size="small">
+            成功
           </Tag>
-          <Tag id="3" color="supportWarning" size="x-small">
-            タグラベル
+          <Tag id="support-warning-sm" color="supportWarning" size="small">
+            警告
+          </Tag>
+          <Tag id="support-danger-sm" color="supportDanger" size="small">
+            危険
           </Tag>
         </div>
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="4" color="supportDanger" size="medium">
-            タグラベル
+        <div className="flex items-center gap-2">
+          <Tag id="support-error-md" color="supportError" size="medium">
+            エラー
           </Tag>
-          <Tag id="4" color="supportDanger" size="small">
-            タグラベル
+          <Tag id="support-success-md" color="supportSuccess" size="medium">
+            成功
           </Tag>
-          <Tag id="4" color="supportDanger" size="x-small">
-            タグラベル
+          <Tag id="support-warning-md" color="supportWarning" size="medium">
+            警告
+          </Tag>
+          <Tag id="support-danger-md" color="supportDanger" size="medium">
+            危険
           </Tag>
         </div>
       </div>
-      <br />
-      <div className="flex items-center gap-x-5">
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="1" color="supportError" variant="light" size="medium">
-            タグラベル
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center gap-2">
+          <Tag id="support-error-light-xs" color="supportError" variant="light" size="x-small">
+            エラー
           </Tag>
-          <Tag id="1" color="supportError" variant="light" size="small">
-            タグラベル
+          <Tag id="support-success-light-xs" color="supportSuccess" variant="light" size="x-small">
+            成功
           </Tag>
-          <Tag id="1" color="supportError" variant="light" size="x-small">
-            タグラベル
+          <Tag id="support-warning-light-xs" color="supportWarning" variant="light" size="x-small">
+            警告
           </Tag>
-        </div>
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="2" color="supportSuccess" variant="light" size="medium">
-            タグラベル
-          </Tag>
-          <Tag id="2" color="supportSuccess" variant="light" size="small">
-            タグラベル
-          </Tag>
-          <Tag id="2" color="supportSuccess" variant="light" size="x-small">
-            タグラベル
+          <Tag id="support-danger-light-xs" color="supportDanger" variant="light" size="x-small">
+            危険
           </Tag>
         </div>
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="3" color="supportWarning" variant="light" size="medium">
-            タグラベル
+        <div className="flex items-center gap-2">
+          <Tag id="support-error-light-sm" color="supportError" variant="light" size="small">
+            エラー
           </Tag>
-          <Tag id="3" color="supportWarning" variant="light" size="small">
-            タグラベル
+          <Tag id="support-success-light-sm" color="supportSuccess" variant="light" size="small">
+            成功
           </Tag>
-          <Tag id="3" color="supportWarning" variant="light" size="x-small">
-            タグラベル
+          <Tag id="support-warning-light-sm" color="supportWarning" variant="light" size="small">
+            警告
+          </Tag>
+          <Tag id="support-danger-light-sm" color="supportDanger" variant="light" size="small">
+            危険
           </Tag>
         </div>
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="4" color="supportDanger" variant="light" size="medium">
-            タグラベル
+        <div className="flex items-center gap-2">
+          <Tag id="support-error-light-md" color="supportError" variant="light" size="medium">
+            エラー
           </Tag>
-          <Tag id="4" color="supportDanger" variant="light" size="small">
-            タグラベル
+          <Tag id="support-success-light-md" color="supportSuccess" variant="light" size="medium">
+            成功
           </Tag>
-          <Tag id="4" color="supportDanger" variant="light" size="x-small">
-            タグラベル
+          <Tag id="support-warning-light-md" color="supportWarning" variant="light" size="medium">
+            警告
+          </Tag>
+          <Tag id="support-danger-light-md" color="supportDanger" variant="light" size="medium">
+            危険
           </Tag>
         </div>
       </div>
-      <br />
-      <h2 className="mb-1 text-gray-gray50">User</h2>
-      <div className="flex flex-wrap items-center gap-5">
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="1" color="userRed" size="medium">
-            タグラベル
-          </Tag>
-          <Tag id="1" color="userRed" size="small">
-            タグラベル
-          </Tag>
-          <Tag id="1" color="userRed" size="x-small">
-            タグラベル
-          </Tag>
-        </div>
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="2" color="userPink" size="medium">
-            タグラベル
-          </Tag>
-          <Tag id="2" color="userPink" size="small">
-            タグラベル
-          </Tag>
-          <Tag id="2" color="userPink" size="x-small">
-            タグラベル
-          </Tag>
-        </div>
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="3" color="userPurple" size="medium">
-            タグラベル
-          </Tag>
-          <Tag id="3" color="userPurple" size="small">
-            タグラベル
-          </Tag>
-          <Tag id="3" color="userPurple" size="x-small">
-            タグラベル
-          </Tag>
-        </div>
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="4" color="userTurquoise" size="medium">
-            タグラベル
-          </Tag>
-          <Tag id="4" color="userTurquoise" size="small">
-            タグラベル
-          </Tag>
-          <Tag id="4" color="userTurquoise" size="x-small">
-            タグラベル
-          </Tag>
-        </div>
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="5" color="userRoyalBlue" size="medium">
-            タグラベル
-          </Tag>
-          <Tag id="5" color="userRoyalBlue" size="small">
-            タグラベル
-          </Tag>
-          <Tag id="5" color="userRoyalBlue" size="x-small">
-            タグラベル
-          </Tag>
-        </div>
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="6" color="userBlue" size="medium">
-            タグラベル
-          </Tag>
-          <Tag id="6" color="userBlue" size="small">
-            タグラベル
-          </Tag>
-          <Tag id="6" color="userBlue" size="x-small">
-            タグラベル
-          </Tag>
-        </div>
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="7" color="userAquamarine" size="medium">
-            タグラベル
-          </Tag>
-          <Tag id="7" color="userAquamarine" size="small">
-            タグラベル
-          </Tag>
-          <Tag id="7" color="userAquamarine" size="x-small">
-            タグラベル
-          </Tag>
-        </div>
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="8" color="userYellowGreen" size="medium">
-            タグラベル
-          </Tag>
-          <Tag id="8" color="userYellowGreen" size="small">
-            タグラベル
-          </Tag>
-          <Tag id="8" color="userYellowGreen" size="x-small">
-            タグラベル
-          </Tag>
-        </div>
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="9" color="userYellow" size="medium">
-            タグラベル
-          </Tag>
-          <Tag id="9" color="userYellow" size="small">
-            タグラベル
-          </Tag>
-          <Tag id="9" color="userYellow" size="x-small">
-            タグラベル
-          </Tag>
-        </div>
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="9" color="userOrange" size="medium">
-            タグラベル
-          </Tag>
-          <Tag id="9" color="userOrange" size="small">
-            タグラベル
-          </Tag>
-          <Tag id="9" color="userOrange" size="x-small">
-            タグラベル
-          </Tag>
-        </div>
-      </div>
-      <br />
-      <div className="flex flex-wrap items-center gap-5">
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="1" color="userRed" variant="light" size="medium">
-            タグラベル
-          </Tag>
-          <Tag id="1" color="userRed" variant="light" size="small">
-            タグラベル
-          </Tag>
-          <Tag id="1" color="userRed" variant="light" size="x-small">
-            タグラベル
-          </Tag>
-        </div>
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="2" color="userPink" variant="light" size="medium">
-            タグラベル
-          </Tag>
-          <Tag id="2" color="userPink" variant="light" size="small">
-            タグラベル
-          </Tag>
-          <Tag id="2" color="userPink" variant="light" size="x-small">
-            タグラベル
-          </Tag>
-        </div>
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="3" color="userPurple" variant="light" size="medium">
-            タグラベル
-          </Tag>
-          <Tag id="3" color="userPurple" variant="light" size="small">
-            タグラベル
-          </Tag>
-          <Tag id="3" color="userPurple" variant="light" size="x-small">
-            タグラベル
-          </Tag>
-        </div>
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="4" color="userTurquoise" variant="light" size="medium">
-            タグラベル
-          </Tag>
-          <Tag id="4" color="userTurquoise" variant="light" size="small">
-            タグラベル
-          </Tag>
-          <Tag id="4" color="userTurquoise" variant="light" size="x-small">
-            タグラベル
-          </Tag>
-        </div>
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="5" color="userRoyalBlue" variant="light" size="medium">
-            タグラベル
-          </Tag>
-          <Tag id="5" color="userRoyalBlue" variant="light" size="small">
-            タグラベル
-          </Tag>
-          <Tag id="5" color="userRoyalBlue" variant="light" size="x-small">
-            タグラベル
-          </Tag>
-        </div>
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="6" color="userBlue" variant="light" size="medium">
-            タグラベル
-          </Tag>
-          <Tag id="6" color="userBlue" variant="light" size="small">
-            タグラベル
-          </Tag>
-          <Tag id="6" color="userBlue" variant="light" size="x-small">
-            タグラベル
-          </Tag>
-        </div>
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="7" color="userAquamarine" variant="light" size="medium">
-            タグラベル
-          </Tag>
-          <Tag id="7" color="userAquamarine" variant="light" size="small">
-            タグラベル
-          </Tag>
-          <Tag id="7" color="userAquamarine" variant="light" size="x-small">
-            タグラベル
-          </Tag>
-        </div>
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="8" color="userYellowGreen" variant="light" size="medium">
-            タグラベル
-          </Tag>
-          <Tag id="8" color="userYellowGreen" variant="light" size="small">
-            タグラベル
-          </Tag>
-          <Tag id="8" color="userYellowGreen" variant="light" size="x-small">
-            タグラベル
-          </Tag>
-        </div>
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="9" color="userYellow" variant="light" size="medium">
-            タグラベル
-          </Tag>
-          <Tag id="9" color="userYellow" variant="light" size="small">
-            タグラベル
-          </Tag>
-          <Tag id="9" color="userYellow" variant="light" size="x-small">
-            タグラベル
-          </Tag>
-        </div>
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="10" color="userOrange" variant="light" size="medium">
-            タグラベル
-          </Tag>
-          <Tag id="10" color="userOrange" variant="light" size="small">
-            タグラベル
-          </Tag>
-          <Tag id="10" color="userOrange" variant="light" size="x-small">
-            タグラベル
-          </Tag>
-        </div>
-      </div>
-      <br />
-      <h2 className="mb-1 text-gray-gray50">Basic</h2>
-      <div className="flex items-center gap-x-5">
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="1" color="default" size="medium">
-            タグラベル
-          </Tag>
-          <Tag id="1" color="default" size="small">
-            タグラベル
-          </Tag>
-          <Tag id="1" color="default" size="x-small">
-            タグラベル
-          </Tag>
-        </div>
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="2" color="gray" size="medium">
-            タグラベル
-          </Tag>
-          <Tag id="2" color="gray" size="small">
-            タグラベル
-          </Tag>
-          <Tag id="2" color="gray" size="x-small">
-            タグラベル
-          </Tag>
-        </div>
-      </div>
-      <br />
-      <div className="flex items-center gap-x-5">
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="1" color="default" variant="light" size="medium">
-            タグラベル
-          </Tag>
-          <Tag id="1" color="default" variant="light" size="small">
-            タグラベル
-          </Tag>
-          <Tag id="1" color="default" variant="light" size="x-small">
-            タグラベル
-          </Tag>
-        </div>
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="2" color="gray" variant="light" size="medium">
-            タグラベル
-          </Tag>
-          <Tag id="2" color="gray" variant="light" size="small">
-            タグラベル
-          </Tag>
-          <Tag id="2" color="gray" variant="light" size="x-small">
-            タグラベル
-          </Tag>
-        </div>
-      </div>
-    </>
-  );
-}
+    </div>
+  ),
+};
 
-export function Editable() {
-  return (
-    <>
-      <h2 className="mb-1 text-gray-gray50">Support</h2>
-      <div className="flex gap-x-3">
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="1" color="supportError" isEditable onDelete={action('tag削除')}>
-            タグラベル
+export const User: Story = {
+  render: () => (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center gap-2">
+          <Tag id="user-red-xs" color="userRed" size="x-small">
+            営業
+          </Tag>
+          <Tag id="user-pink-xs" color="userPink" size="x-small">
+            広報
+          </Tag>
+          <Tag id="user-purple-xs" color="userPurple" size="x-small">
+            企画
+          </Tag>
+          <Tag id="user-turquoise-xs" color="userTurquoise" size="x-small">
+            開発
+          </Tag>
+          <Tag id="user-royal-blue-xs" color="userRoyalBlue" size="x-small">
+            デザイン
+          </Tag>
+          <Tag id="user-blue-xs" color="userBlue" size="x-small">
+            CS
+          </Tag>
+          <Tag id="user-aquamarine-xs" color="userAquamarine" size="x-small">
+            人事
+          </Tag>
+          <Tag id="user-yellow-green-xs" color="userYellowGreen" size="x-small">
+            法務
+          </Tag>
+          <Tag id="user-yellow-xs" color="userYellow" size="x-small">
+            経理
+          </Tag>
+          <Tag id="user-orange-xs" color="userOrange" size="x-small">
+            総務
           </Tag>
         </div>
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="2" color="supportSuccess" isEditable onDelete={action('tag削除')}>
-            タグラベル
+        <div className="flex items-center gap-2">
+          <Tag id="user-red-sm" color="userRed" size="small">
+            営業
+          </Tag>
+          <Tag id="user-pink-sm" color="userPink" size="small">
+            広報
+          </Tag>
+          <Tag id="user-purple-sm" color="userPurple" size="small">
+            企画
+          </Tag>
+          <Tag id="user-turquoise-sm" color="userTurquoise" size="small">
+            開発
+          </Tag>
+          <Tag id="user-royal-blue-sm" color="userRoyalBlue" size="small">
+            デザイン
+          </Tag>
+          <Tag id="user-blue-sm" color="userBlue" size="small">
+            CS
+          </Tag>
+          <Tag id="user-aquamarine-sm" color="userAquamarine" size="small">
+            人事
+          </Tag>
+          <Tag id="user-yellow-green-sm" color="userYellowGreen" size="small">
+            法務
+          </Tag>
+          <Tag id="user-yellow-sm" color="userYellow" size="small">
+            経理
+          </Tag>
+          <Tag id="user-orange-sm" color="userOrange" size="small">
+            総務
           </Tag>
         </div>
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="3" color="supportWarning" isEditable onDelete={action('tag削除')}>
-            タグラベル
+        <div className="flex items-center gap-2">
+          <Tag id="user-red-md" color="userRed" size="medium">
+            営業
           </Tag>
-        </div>
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="4" color="supportDanger" isEditable onDelete={action('tag削除')}>
-            タグラベル
+          <Tag id="user-pink-md" color="userPink" size="medium">
+            広報
           </Tag>
-        </div>
-      </div>
-      <br />
-      <div className="flex gap-x-3">
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="1" color="supportError" variant="light" isEditable onDelete={action('tag削除')}>
-            タグラベル
+          <Tag id="user-purple-md" color="userPurple" size="medium">
+            企画
           </Tag>
-        </div>
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="2" color="supportSuccess" variant="light" isEditable onDelete={action('tag削除')}>
-            タグラベル
+          <Tag id="user-turquoise-md" color="userTurquoise" size="medium">
+            開発
           </Tag>
-        </div>
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="3" color="supportWarning" variant="light" isEditable onDelete={action('tag削除')}>
-            タグラベル
+          <Tag id="user-royal-blue-md" color="userRoyalBlue" size="medium">
+            デザイン
           </Tag>
-        </div>
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="4" color="supportDanger" variant="light" isEditable onDelete={action('tag削除')}>
-            タグラベル
+          <Tag id="user-blue-md" color="userBlue" size="medium">
+            CS
           </Tag>
-        </div>
-      </div>
-      <br />
-      <h2 className="mb-1 text-gray-gray50">User</h2>
-      <div className="flex gap-x-3">
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="1" color="userRed" isEditable onDelete={action('tag削除')}>
-            タグラベル
+          <Tag id="user-aquamarine-md" color="userAquamarine" size="medium">
+            人事
           </Tag>
-        </div>
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="2" color="userPink" isEditable onDelete={action('tag削除')}>
-            タグラベル
+          <Tag id="user-yellow-green-md" color="userYellowGreen" size="medium">
+            法務
           </Tag>
-        </div>
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="3" color="userPurple" isEditable onDelete={action('tag削除')}>
-            タグラベル
+          <Tag id="user-yellow-md" color="userYellow" size="medium">
+            経理
           </Tag>
-        </div>
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="4" color="userTurquoise" isEditable onDelete={action('tag削除')}>
-            タグラベル
-          </Tag>
-        </div>
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="5" color="userRoyalBlue" isEditable onDelete={action('tag削除')}>
-            タグラベル
-          </Tag>
-        </div>
-      </div>
-      <br />
-      <div className="flex gap-x-3">
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="6" color="userBlue" isEditable onDelete={action('tag削除')}>
-            タグラベル
-          </Tag>
-        </div>
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="7" color="userAquamarine" isEditable onDelete={action('tag削除')}>
-            タグラベル
-          </Tag>
-        </div>
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="8" color="userYellowGreen" isEditable onDelete={action('tag削除')}>
-            タグラベル
-          </Tag>
-        </div>
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="9" color="userYellow" isEditable onDelete={action('tag削除')}>
-            タグラベル
-          </Tag>
-        </div>
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="10" color="userOrange" isEditable onDelete={action('tag削除')}>
-            タグラベル
+          <Tag id="user-orange-md" color="userOrange" size="medium">
+            総務
           </Tag>
         </div>
       </div>
-      <br />
-      <div className="flex gap-x-3">
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="1" color="userRed" variant="light" isEditable onDelete={action('tag削除')}>
-            タグラベル
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center gap-2">
+          <Tag id="user-red-light-xs" color="userRed" variant="light" size="x-small">
+            営業
+          </Tag>
+          <Tag id="user-pink-light-xs" color="userPink" variant="light" size="x-small">
+            広報
+          </Tag>
+          <Tag id="user-purple-light-xs" color="userPurple" variant="light" size="x-small">
+            企画
+          </Tag>
+          <Tag id="user-turquoise-light-xs" color="userTurquoise" variant="light" size="x-small">
+            開発
+          </Tag>
+          <Tag id="user-royal-blue-light-xs" color="userRoyalBlue" variant="light" size="x-small">
+            デザイン
+          </Tag>
+          <Tag id="user-blue-light-xs" color="userBlue" variant="light" size="x-small">
+            CS
+          </Tag>
+          <Tag id="user-aquamarine-light-xs" color="userAquamarine" variant="light" size="x-small">
+            人事
+          </Tag>
+          <Tag id="user-yellow-green-light-xs" color="userYellowGreen" variant="light" size="x-small">
+            法務
+          </Tag>
+          <Tag id="user-yellow-light-xs" color="userYellow" variant="light" size="x-small">
+            経理
+          </Tag>
+          <Tag id="user-orange-light-xs" color="userOrange" variant="light" size="x-small">
+            総務
           </Tag>
         </div>
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="2" color="userPink" variant="light" isEditable onDelete={action('tag削除')}>
-            タグラベル
+        <div className="flex items-center gap-2">
+          <Tag id="user-red-light-sm" color="userRed" variant="light" size="small">
+            営業
+          </Tag>
+          <Tag id="user-pink-light-sm" color="userPink" variant="light" size="small">
+            広報
+          </Tag>
+          <Tag id="user-purple-light-sm" color="userPurple" variant="light" size="small">
+            企画
+          </Tag>
+          <Tag id="user-turquoise-light-sm" color="userTurquoise" variant="light" size="small">
+            開発
+          </Tag>
+          <Tag id="user-royal-blue-light-sm" color="userRoyalBlue" variant="light" size="small">
+            デザイン
+          </Tag>
+          <Tag id="user-blue-light-sm" color="userBlue" variant="light" size="small">
+            CS
+          </Tag>
+          <Tag id="user-aquamarine-light-sm" color="userAquamarine" variant="light" size="small">
+            人事
+          </Tag>
+          <Tag id="user-yellow-green-light-sm" color="userYellowGreen" variant="light" size="small">
+            法務
+          </Tag>
+          <Tag id="user-yellow-light-sm" color="userYellow" variant="light" size="small">
+            経理
+          </Tag>
+          <Tag id="user-orange-light-sm" color="userOrange" variant="light" size="small">
+            総務
           </Tag>
         </div>
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="3" color="userPurple" variant="light" isEditable onDelete={action('tag削除')}>
-            タグラベル
+        <div className="flex items-center gap-2">
+          <Tag id="user-red-light-md" color="userRed" variant="light" size="medium">
+            営業
           </Tag>
-        </div>
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="4" color="userTurquoise" variant="light" isEditable onDelete={action('tag削除')}>
-            タグラベル
+          <Tag id="user-pink-light-md" color="userPink" variant="light" size="medium">
+            広報
           </Tag>
-        </div>
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="5" color="userRoyalBlue" variant="light" isEditable onDelete={action('tag削除')}>
-            タグラベル
+          <Tag id="user-purple-light-md" color="userPurple" variant="light" size="medium">
+            企画
+          </Tag>
+          <Tag id="user-turquoise-light-md" color="userTurquoise" variant="light" size="medium">
+            開発
+          </Tag>
+          <Tag id="user-royal-blue-light-md" color="userRoyalBlue" variant="light" size="medium">
+            デザイン
+          </Tag>
+          <Tag id="user-blue-light-md" color="userBlue" variant="light" size="medium">
+            CS
+          </Tag>
+          <Tag id="user-aquamarine-light-md" color="userAquamarine" variant="light" size="medium">
+            人事
+          </Tag>
+          <Tag id="user-yellow-green-light-md" color="userYellowGreen" variant="light" size="medium">
+            法務
+          </Tag>
+          <Tag id="user-yellow-light-md" color="userYellow" variant="light" size="medium">
+            経理
+          </Tag>
+          <Tag id="user-orange-light-md" color="userOrange" variant="light" size="medium">
+            総務
           </Tag>
         </div>
       </div>
-      <br />
-      <div className="flex gap-x-3">
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="6" color="userBlue" variant="light" isEditable onDelete={action('tag削除')}>
-            タグラベル
-          </Tag>
-        </div>
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="7" color="userAquamarine" variant="light" isEditable onDelete={action('tag削除')}>
-            タグラベル
-          </Tag>
-        </div>
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="8" color="userYellowGreen" variant="light" isEditable onDelete={action('tag削除')}>
-            タグラベル
-          </Tag>
-        </div>
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="9" color="userYellow" variant="light" isEditable onDelete={action('tag削除')}>
-            タグラベル
-          </Tag>
-        </div>
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="10" color="userOrange" variant="light" isEditable onDelete={action('tag削除')}>
-            タグラベル
-          </Tag>
-        </div>
-      </div>
-      <br />
-      <h2 className="mb-1 text-gray-gray50">Default</h2>
-      <div className="flex gap-x-3">
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="1" color="default" isEditable onDelete={action('tag削除')}>
-            タグラベル
-          </Tag>
-        </div>
+    </div>
+  ),
+};
 
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="2" color="gray" isEditable onDelete={action('tag削除')}>
-            タグラベル
+export const Basic: Story = {
+  render: () => (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center gap-2">
+          <Tag id="basic-default-xs" color="default" size="x-small">
+            通常
+          </Tag>
+          <Tag id="basic-gray-xs" color="gray" size="x-small">
+            グレー
+          </Tag>
+        </div>
+        <div className="flex items-center gap-2">
+          <Tag id="basic-default-sm" color="default" size="small">
+            通常
+          </Tag>
+          <Tag id="basic-gray-sm" color="gray" size="small">
+            グレー
+          </Tag>
+        </div>
+        <div className="flex items-center gap-2">
+          <Tag id="basic-default-md" color="default" size="medium">
+            通常
+          </Tag>
+          <Tag id="basic-gray-md" color="gray" size="medium">
+            グレー
           </Tag>
         </div>
       </div>
-      <br />
-      <div className="flex gap-x-3">
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="1" color="default" variant="light" isEditable onDelete={action('tag削除')}>
-            タグラベル
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center gap-2">
+          <Tag id="basic-default-light-xs" color="default" variant="light" size="x-small">
+            通常
+          </Tag>
+          <Tag id="basic-gray-light-xs" color="gray" variant="light" size="x-small">
+            グレー
           </Tag>
         </div>
+        <div className="flex items-center gap-2">
+          <Tag id="basic-default-light-sm" color="default" variant="light" size="small">
+            通常
+          </Tag>
+          <Tag id="basic-gray-light-sm" color="gray" variant="light" size="small">
+            グレー
+          </Tag>
+        </div>
+        <div className="flex items-center gap-2">
+          <Tag id="basic-default-light-md" color="default" variant="light" size="medium">
+            通常
+          </Tag>
+          <Tag id="basic-gray-light-md" color="gray" variant="light" size="medium">
+            グレー
+          </Tag>
+        </div>
+      </div>
+    </div>
+  ),
+};
 
-        <div className="grid justify-items-start gap-y-2">
-          <Tag id="2" color="gray" variant="light" isEditable onDelete={action('tag削除')}>
-            タグラベル
+export const Editable: Story = {
+  render: () => (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center gap-2">
+          <Tag id="edit-supportError-normal" color="supportError" isEditable onDelete={action('tag削除')}>
+            エラー
+          </Tag>
+          <Tag id="edit-supportSuccess-normal" color="supportSuccess" isEditable onDelete={action('tag削除')}>
+            成功
+          </Tag>
+          <Tag id="edit-supportWarning-normal" color="supportWarning" isEditable onDelete={action('tag削除')}>
+            警告
+          </Tag>
+          <Tag id="edit-supportDanger-normal" color="supportDanger" isEditable onDelete={action('tag削除')}>
+            危険
+          </Tag>
+        </div>
+        <div className="flex items-center gap-2">
+          <Tag
+            id="edit-supportError-light"
+            color="supportError"
+            variant="light"
+            isEditable
+            onDelete={action('tag削除')}
+          >
+            エラー
+          </Tag>
+          <Tag
+            id="edit-supportSuccess-light"
+            color="supportSuccess"
+            variant="light"
+            isEditable
+            onDelete={action('tag削除')}
+          >
+            成功
+          </Tag>
+          <Tag
+            id="edit-supportWarning-light"
+            color="supportWarning"
+            variant="light"
+            isEditable
+            onDelete={action('tag削除')}
+          >
+            警告
+          </Tag>
+          <Tag
+            id="edit-supportDanger-light"
+            color="supportDanger"
+            variant="light"
+            isEditable
+            onDelete={action('tag削除')}
+          >
+            危険
           </Tag>
         </div>
       </div>
-    </>
-  );
-}
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center gap-2">
+          <Tag id="edit-userRed-normal" color="userRed" isEditable onDelete={action('tag削除')}>
+            営業
+          </Tag>
+          <Tag id="edit-userPink-normal" color="userPink" isEditable onDelete={action('tag削除')}>
+            広報
+          </Tag>
+          <Tag id="edit-userPurple-normal" color="userPurple" isEditable onDelete={action('tag削除')}>
+            企画
+          </Tag>
+          <Tag id="edit-userTurquoise-normal" color="userTurquoise" isEditable onDelete={action('tag削除')}>
+            開発
+          </Tag>
+          <Tag id="edit-userRoyalBlue-normal" color="userRoyalBlue" isEditable onDelete={action('tag削除')}>
+            デザイン
+          </Tag>
+          <Tag id="edit-userBlue-normal" color="userBlue" isEditable onDelete={action('tag削除')}>
+            CS
+          </Tag>
+          <Tag id="edit-userAquamarine-normal" color="userAquamarine" isEditable onDelete={action('tag削除')}>
+            人事
+          </Tag>
+          <Tag id="edit-userYellowGreen-normal" color="userYellowGreen" isEditable onDelete={action('tag削除')}>
+            法務
+          </Tag>
+          <Tag id="edit-userYellow-normal" color="userYellow" isEditable onDelete={action('tag削除')}>
+            経理
+          </Tag>
+          <Tag id="edit-userOrange-normal" color="userOrange" isEditable onDelete={action('tag削除')}>
+            総務
+          </Tag>
+        </div>
+        <div className="flex items-center gap-2">
+          <Tag id="edit-userRed-light" color="userRed" variant="light" isEditable onDelete={action('tag削除')}>
+            営業
+          </Tag>
+          <Tag id="edit-userPink-light" color="userPink" variant="light" isEditable onDelete={action('tag削除')}>
+            広報
+          </Tag>
+          <Tag id="edit-userPurple-light" color="userPurple" variant="light" isEditable onDelete={action('tag削除')}>
+            企画
+          </Tag>
+          <Tag
+            id="edit-userTurquoise-light"
+            color="userTurquoise"
+            variant="light"
+            isEditable
+            onDelete={action('tag削除')}
+          >
+            開発
+          </Tag>
+          <Tag
+            id="edit-userRoyalBlue-light"
+            color="userRoyalBlue"
+            variant="light"
+            isEditable
+            onDelete={action('tag削除')}
+          >
+            デザイン
+          </Tag>
+          <Tag id="edit-userBlue-light" color="userBlue" variant="light" isEditable onDelete={action('tag削除')}>
+            CS
+          </Tag>
+          <Tag
+            id="edit-userAquamarine-light"
+            color="userAquamarine"
+            variant="light"
+            isEditable
+            onDelete={action('tag削除')}
+          >
+            人事
+          </Tag>
+          <Tag
+            id="edit-userYellowGreen-light"
+            color="userYellowGreen"
+            variant="light"
+            isEditable
+            onDelete={action('tag削除')}
+          >
+            法務
+          </Tag>
+          <Tag id="edit-userYellow-light" color="userYellow" variant="light" isEditable onDelete={action('tag削除')}>
+            経理
+          </Tag>
+          <Tag id="edit-userOrange-light" color="userOrange" variant="light" isEditable onDelete={action('tag削除')}>
+            総務
+          </Tag>
+        </div>
+      </div>
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center gap-2">
+          <Tag id="edit-default-normal" color="default" isEditable onDelete={action('tag削除')}>
+            通常
+          </Tag>
+          <Tag id="edit-gray-normal" color="gray" isEditable onDelete={action('tag削除')}>
+            グレー
+          </Tag>
+        </div>
+        <div className="flex items-center gap-2">
+          <Tag id="edit-default-light" color="default" variant="light" isEditable onDelete={action('tag削除')}>
+            通常
+          </Tag>
+          <Tag id="edit-gray-light" color="gray" variant="light" isEditable onDelete={action('tag削除')}>
+            グレー
+          </Tag>
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/packages/component-ui/src/tag/tag.test.tsx
+++ b/packages/component-ui/src/tag/tag.test.tsx
@@ -1,0 +1,197 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { Tag } from './tag';
+
+/**
+ * Tag テストについて
+ *
+ * テストの構成：
+ * - 基本機能：レンダリング、children 反映
+ * - size：x-small / small / medium のクラス反映、デフォルト値
+ * - variant：normal / light のクラストークン反映
+ * - isEditable：編集可能モードでの削除ボタン描画とサイズ・形状クラス
+ * - 削除インタラクション：onDelete に id が渡ること、複数 Tag での id 区別
+ */
+
+describe('Tag', () => {
+  describe('基本機能', () => {
+    it('children に渡したテキストが表示されること', () => {
+      render(
+        <Tag id="tag-1" color="default">
+          タグテキスト
+        </Tag>,
+      );
+      expect(screen.getByText('タグテキスト')).toBeInTheDocument();
+    });
+
+    it('color を変えると tagColors のクラスが付与されること', () => {
+      const { container } = render(
+        <Tag id="tag-1" color="supportError">
+          ラベル
+        </Tag>,
+      );
+      const wrapper = container.firstElementChild as HTMLElement;
+      expect(wrapper.className).toMatch(/bg-supportError/);
+    });
+  });
+
+  describe('size', () => {
+    it('size="x-small" の場合、対応する高さクラスが付与されること', () => {
+      const { container } = render(
+        <Tag id="tag-1" color="default" size="x-small">
+          ラベル
+        </Tag>,
+      );
+      const wrapper = container.firstElementChild as HTMLElement;
+      expect(wrapper.className).toMatch(/h-\[14px\]/);
+    });
+
+    it('size="small" の場合、対応する高さクラスが付与されること', () => {
+      const { container } = render(
+        <Tag id="tag-1" color="default" size="small">
+          ラベル
+        </Tag>,
+      );
+      const wrapper = container.firstElementChild as HTMLElement;
+      expect(wrapper.className).toMatch(/h-4/);
+    });
+
+    it('size="medium" の場合、対応する高さクラスが付与されること', () => {
+      const { container } = render(
+        <Tag id="tag-1" color="default" size="medium">
+          ラベル
+        </Tag>,
+      );
+      const wrapper = container.firstElementChild as HTMLElement;
+      expect(wrapper.className).toMatch(/h-\[18px\]/);
+    });
+
+    it('size 未指定時は medium がデフォルトになること', () => {
+      const { container } = render(
+        <Tag id="tag-1" color="default">
+          ラベル
+        </Tag>,
+      );
+      const wrapper = container.firstElementChild as HTMLElement;
+      expect(wrapper.className).toMatch(/h-\[18px\]/);
+    });
+  });
+
+  describe('variant', () => {
+    it('variant 未指定時は tagColors（normal）のクラスが付与されること', () => {
+      const { container } = render(
+        <Tag id="tag-1" color="supportError">
+          ラベル
+        </Tag>,
+      );
+      const wrapper = container.firstElementChild as HTMLElement;
+      expect(wrapper.className).toMatch(/bg-supportError(?!Light)/);
+    });
+
+    it('variant="light" の場合、tagLightColors のクラスが付与されること', () => {
+      const { container } = render(
+        <Tag id="tag-1" color="supportError" variant="light">
+          ラベル
+        </Tag>,
+      );
+      const wrapper = container.firstElementChild as HTMLElement;
+      expect(wrapper.className).toMatch(/bg-supportErrorLight/);
+    });
+  });
+
+  describe('isEditable', () => {
+    it('isEditable 未指定の場合、削除ボタンが描画されないこと', () => {
+      render(
+        <Tag id="tag-1" color="default">
+          ラベル
+        </Tag>,
+      );
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    });
+
+    it('isEditable=true の場合、削除ボタンが 1 つ描画されること', () => {
+      const handleDelete = vi.fn();
+      render(
+        <Tag id="tag-1" color="default" isEditable onDelete={handleDelete}>
+          ラベル
+        </Tag>,
+      );
+      const buttons = screen.getAllByRole('button');
+      expect(buttons).toHaveLength(1);
+    });
+
+    it('isEditable=true の場合、rounded-full クラスが付与されること', () => {
+      const handleDelete = vi.fn();
+      const { container } = render(
+        <Tag id="tag-1" color="default" isEditable onDelete={handleDelete}>
+          ラベル
+        </Tag>,
+      );
+      const wrapper = container.firstElementChild as HTMLElement;
+      expect(wrapper.className).toMatch(/rounded-full/);
+    });
+
+    it('isEditable=true の場合、編集モード固有の高さクラスが付与されること', () => {
+      const handleDelete = vi.fn();
+      const { container } = render(
+        <Tag id="tag-1" color="default" isEditable onDelete={handleDelete}>
+          ラベル
+        </Tag>,
+      );
+      const wrapper = container.firstElementChild as HTMLElement;
+      expect(wrapper.className).toMatch(/h-\[22px\]/);
+    });
+  });
+
+  describe('削除インタラクション', () => {
+    it('削除ボタンクリック時に onDelete が呼ばれること', async () => {
+      const user = userEvent.setup();
+      const handleDelete = vi.fn();
+      render(
+        <Tag id="tag-1" color="default" isEditable onDelete={handleDelete}>
+          ラベル
+        </Tag>,
+      );
+      await user.click(screen.getByRole('button'));
+      expect(handleDelete).toHaveBeenCalledTimes(1);
+    });
+
+    it('onDelete には Tag に渡した id が引数として渡ること', async () => {
+      const user = userEvent.setup();
+      const handleDelete = vi.fn();
+      render(
+        <Tag id="tag-1" color="default" isEditable onDelete={handleDelete}>
+          ラベル
+        </Tag>,
+      );
+      await user.click(screen.getByRole('button'));
+      expect(handleDelete).toHaveBeenCalledWith('tag-1');
+    });
+
+    it('複数 Tag のうち、クリックされた Tag の id のみが渡ること', async () => {
+      const user = userEvent.setup();
+      const handleDelete = vi.fn();
+      render(
+        <div>
+          <Tag id="tag-a" color="default" isEditable onDelete={handleDelete}>
+            A
+          </Tag>
+          <Tag id="tag-b" color="gray" isEditable onDelete={handleDelete}>
+            B
+          </Tag>
+        </div>,
+      );
+      const buttons = screen.getAllByRole('button');
+      const secondButton = buttons[1];
+      if (secondButton == null) {
+        throw new Error('2 つ目の削除ボタンが見つかりません');
+      }
+      await user.click(secondButton);
+      expect(handleDelete).toHaveBeenCalledTimes(1);
+      expect(handleDelete).toHaveBeenCalledWith('tag-b');
+    });
+  });
+});


### PR DESCRIPTION
> [!NOTE]
> - Storybook の 改善タスク
>  - Testコードの追加

## 概要

Tag の Storybook を Button / Radio / Checkbox と同じ方針で分割し、Chromatic のビジュアルリグレッション差分の影響範囲を最小化する。あわせて未整備だったユニットテストを新規追加する。

## 変更点

### Story の分割（`tag.stories.tsx`）

- 既存の `Basic` Story（16 色 × 3 size × 2 variant = 96 セルを 1 スナップショットに詰め込み）を廃止
- `color` の意味カテゴリで Story を分割:
  - `Support` — `supportError` / `supportSuccess` / `supportWarning` / `supportDanger`
  - `User` — `userRed` / `userPink` / ... の 10 色
  - `Basic` — `default` / `gray`
- `Editable` — 編集可能タグ（`isEditable=true`、size 固定 medium）の全 16 色 × 2 variant
- `Component` — args 駆動 + `chromatic: { disable: true }`（既存維持）
- 各 render 固定 Story 内は外側 `flex flex-col gap-6`、内側 `flex flex-col gap-2` / `flex items-center gap-2` で「`variant` ブロック × `size` 行 × `color` 列」のマトリクスを構築
- `<br/>` / `<h2>` / 冗長な `grid` ラッパーを除去し `flex flex-col gap-*` レイアウトに統一
- `export function Basic()` を `const Basic: Story = {...}` 形式に統一（Button / Radio / Checkbox と一致）
- ダミーテキスト「タグラベル」を実用的なラベル（エラー / 成功 / 営業 / 開発 / 通常 等）に置換
- `id` を `support-error-xs` / `edit-supportError-normal` のような接頭辞付き形式で一意化

### ユニットテストの新規追加（`tag.test.tsx`）

`packages/component-ui/src/tag/` にはこれまでテストファイルが無かったため、Vitest + React Testing Library で新規追加。改訂版 Storybook ガイドライン「play function とユニットテストの使い分け」に従い、`Editable` の削除インタラクション検証は play function ではなくユニットテスト側に集約した。

| describe | 観点 |
|---|---|
| 基本機能 | レンダリング、`children` 反映、`color` のクラストークン適用 |
| size | `x-small` / `small` / `medium` の高さクラスとデフォルト値 |
| variant | `normal` / `light` の `tagColors` / `tagLightColors` 適用 |
| isEditable | 編集モード時の削除ボタン描画、`rounded-full` / `h-[22px]` クラス |
| 削除インタラクション | `onDelete` 呼び出し、`id` 引数の検証、複数 Tag での id 区別 |

合計 15 ケース。

## 参考

- Story 分割方針は #560 (Button) / #562 (Radio) / #564 (Checkbox) に準拠
- 「主要軸の値が多い（10 種以上）コンポーネントの分割パターン」と「play function とユニットテストの使い分け」は本 PR の base ブランチに含まれる `docs/storybook-guidelines.md` の改訂で先行整備済み

## PR の依存関係

本 PR は #560 (\`refactor(Storybook:button): split stories by variant\`) を base にした **stacked PR** です。

## 実行したコマンド

- \`yarn type-check\` ✅
- \`yarn eslint packages/component-ui/src/tag/tag.stories.tsx packages/component-ui/src/tag/tag.test.tsx\` ✅
- \`yarn prettier --check packages/component-ui/src/tag/tag.stories.tsx packages/component-ui/src/tag/tag.test.tsx\` ✅
- \`yarn test --run src/tag/tag.test.tsx\` ✅ (15 passed)
- \`yarn test:ci\` ✅ (431 passed / 2 skipped)

## Test plan

- [ ] \`yarn storybook\` で \`Components/Tag\` 配下に 5 Story (\`Component\` / \`Support\` / \`User\` / \`Basic\` / \`Editable\`) が並ぶこと
- [ ] \`Component\` Story の Controls パネルで `size` / `variant` / `color` / `children` / `onDelete` が操作できること
- [ ] \`Component\` Story のみ Chromatic disable
- [ ] \`Support\` Story で 4 色 × 3 size × 2 variant のマトリクスが正しく表示されること
- [ ] \`User\` Story で 10 色 × 3 size × 2 variant のマトリクスが正しく表示されること
- [ ] \`Basic\` Story で 2 色 × 3 size × 2 variant のマトリクスが正しく表示されること
- [ ] \`Editable\` Story で 16 色 × 2 variant の編集可能タグが表示され、削除ボタンクリックで Actions パネルにイベントが流れること
- [ ] Chromatic のビジュアルリグレッション差分が想定通り（既存 Basic 削除 + 新規 Support / User / Basic / Editable 追加）であること