### PR TITLE
294｜fix(tag): unify medium height to 20px and remove vertical padding

### DIFF
--- a/packages/component-ui/src/tag/tag.stories.tsx
+++ b/packages/component-ui/src/tag/tag.stories.tsx
@@ -9,7 +9,7 @@ const meta: Meta<typeof Tag> = {
   argTypes: {
     variant: {
       options: ['normal', 'light'],
-      control: { type: 'select' },
+      control: { type: 'radio' },
       description: '濃色(normal) / 淡色(light)のスタイル',
       table: {
         type: { summary: `'normal' | 'light'` },
@@ -18,7 +18,7 @@ const meta: Meta<typeof Tag> = {
     },
     size: {
       options: ['x-small', 'small', 'medium'],
-      control: { type: 'select' },
+      control: { type: 'radio' },
       description: '標準タグのサイズ。編集可能タグは常にmedium固定。',
       table: {
         type: { summary: `'x-small' | 'small' | 'medium'` },
@@ -44,7 +44,7 @@ const meta: Meta<typeof Tag> = {
         'default',
         'gray',
       ],
-      control: { type: 'select' },
+      control: { type: 'radio' },
       description: 'tagColors / tagLightColors で定義されたカラートークン',
     },
     children: {

--- a/packages/component-ui/src/tag/tag.test.tsx
+++ b/packages/component-ui/src/tag/tag.test.tsx
@@ -66,7 +66,7 @@ describe('Tag', () => {
         </Tag>,
       );
       const wrapper = container.firstElementChild as HTMLElement;
-      expect(wrapper.className).toMatch(/h-\[18px\]/);
+      expect(wrapper.className).toMatch(/h-5/);
     });
 
     it('size 未指定時は medium がデフォルトになること', () => {
@@ -76,7 +76,7 @@ describe('Tag', () => {
         </Tag>,
       );
       const wrapper = container.firstElementChild as HTMLElement;
-      expect(wrapper.className).toMatch(/h-\[18px\]/);
+      expect(wrapper.className).toMatch(/h-5/);
     });
   });
 
@@ -142,7 +142,7 @@ describe('Tag', () => {
         </Tag>,
       );
       const wrapper = container.firstElementChild as HTMLElement;
-      expect(wrapper.className).toMatch(/h-\[22px\]/);
+      expect(wrapper.className).toMatch(/h-5/);
     });
   });
 

--- a/packages/component-ui/src/tag/tag.tsx
+++ b/packages/component-ui/src/tag/tag.tsx
@@ -38,12 +38,11 @@ export function Tag({ id, children, color, variant = 'normal', size = 'medium', 
     [tagLightColors[color]]: variant === 'light',
     'h-[14px] typography-label11regular': !isEditable && size === 'x-small',
     'h-4 typography-label12regular': !isEditable && size === 'small',
-    'h-[18px] typography-label14regular': !isEditable && size === 'medium',
-    'h-[22px] typography-label14regular': isEditable && size === 'medium',
+    'h-5 typography-label14regular': size === 'medium',
     'rounded-full': isEditable,
     rounded: !isEditable,
-    'py-0.5 px-1': !isEditable,
-    'py-1 px-2': isEditable,
+    'px-1': !isEditable,
+    'px-2': isEditable,
   });
 
   return (


### PR DESCRIPTION
## 概要

Tag コンポーネントの medium サイズの高さが編集可（22px）/不可（18px）で異なっていたのを **20px に統一**する。あわせて全 size から上下 padding を除去し、高さを `h-[]` のみで固定する方針に変更する。

## 変更点

### `tag.tsx`

| 項目 | before | after |
|---|---|---|
| medium（非編集） | `h-[18px]` + `py-0.5` | `h-5`（20px） |
| medium（編集可） | `h-[22px]` + `py-1` | `h-5`（20px） |
| x-small | `h-[14px]` + `py-0.5` | `h-[14px]`（py 除去） |
| small | `h-4` + `py-0.5` | `h-4`（py 除去） |

- medium の 2 条件（`!isEditable && size === 'medium'` / `isEditable && size === 'medium'`）を `size === 'medium'` 1 行に統合
- 水平 padding（`px-1` / `px-2`）は維持

### `tag.test.tsx`

- `h-[18px]` / `h-[22px]` のアサーション 3 箇所を `h-5` に修正

### `tag.stories.tsx`

- `variant` / `size` の argTypes control を `select` → `radio` に変更（Button / IconButton 等の先例に準拠）

## PR の依存関係

本 PR は #567 (`refactor(Storybook:tag): split stories by color category`) を base にした **stacked PR** です。

## 実行したコマンド

- \`yarn test --run src/tag/tag.test.tsx\` ✅ (15 passed)
- \`yarn eslint packages/component-ui/src/tag/tag.tsx packages/component-ui/src/tag/tag.test.tsx\` ✅
- \`yarn type-check\` ✅
- Storybook 目視確認 ✅（削除アイコンの収まりも問題なし）

## Test plan

- [ ] Storybook で全 Tag Story（Support / User / Basic / Editable / Component）の見た目が正常であること
- [ ] medium サイズが編集可/不可ともに 20px の高さで統一されていること
- [ ] x-small / small の見た目が変更前と大きく変わっていないこと（高さは維持、py 除去の影響が軽微であること）
- [ ] Editable タグの削除アイコンが 20px の高さ内に収まっていること
- [ ] Chromatic のビジュアルリグレッション差分が全 size × variant で想定通りであること