### PR TITLE
docs(Storybook: Tooltip): improve stories (reproduction + guideline alignment)

### DIFF
--- a/packages/component-ui/src/tooltip/tooltip.stories.tsx
+++ b/packages/component-ui/src/tooltip/tooltip.stories.tsx
@@ -1,24 +1,21 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 
+import { Button } from '../button';
 import { Tooltip } from './tooltip';
 
 const meta: Meta<typeof Tooltip> = {
   title: 'Components/Tooltip',
   component: Tooltip,
   argTypes: {
-    size: {
-      options: ['small', 'medium'],
-      control: 'select',
-    },
-    verticalPosition: {
-      options: ['top', 'bottom'],
-      control: 'select',
-    },
-    horizontalAlign: {
-      options: ['left', 'center', 'right'],
-      control: 'select',
-    },
+    size: { control: 'select', options: ['small', 'medium'] },
+    verticalPosition: { control: 'radio', options: ['top', 'bottom'] },
+    horizontalAlign: { control: 'radio', options: ['left', 'center', 'right'] },
+    content: { control: 'text' },
+    maxWidth: { control: 'number' },
+    isDisabledHover: { control: 'boolean' },
+    portalTarget: { control: false },
+    children: { control: false },
   },
 };
 
@@ -28,6 +25,8 @@ type Story = StoryObj<typeof Tooltip>;
 export const Component: Story = {
   args: {
     size: 'small',
+    verticalPosition: 'bottom',
+    horizontalAlign: 'center',
     content: (
       <>
         内容説明テキスト1
@@ -40,10 +39,12 @@ export const Component: Story = {
     chromatic: { disable: true },
   },
   render: (args) => (
-    <div className="grid gap-10 px-20 py-10">
+    <div className="flex flex-col gap-10 px-20 py-10">
       <div className="flex items-center gap-20">
         <Tooltip {...args}>
-          <div className="flex h-10 w-[240px] items-center justify-center rounded border border-gray-400">target</div>
+          <Button variant="outline" size="small">
+            ラベル
+          </Button>
         </Tooltip>
       </div>
     </div>
@@ -51,25 +52,30 @@ export const Component: Story = {
 };
 
 export const Base: Story = {
-  args: {
-    content: (
-      <>
-        内容説明テキスト1
-        <br />
-        内容説明テキスト2
-      </>
-    ),
-  },
-  render: (args) => (
-    <div className="grid gap-10 px-20 py-10">
+  render: () => (
+    <div className="flex flex-col gap-16 p-20">
       <div className="flex items-center gap-20">
-        <Tooltip {...args}>
-          <div className="flex h-10 w-24 items-center justify-center rounded border border-gray-400">target</div>
+        <Tooltip content="内容説明テキスト" size="small" verticalPosition="top">
+          <Button variant="outline" size="small">
+            small / top
+          </Button>
+        </Tooltip>
+        <Tooltip content="内容説明テキスト" size="small" verticalPosition="bottom">
+          <Button variant="outline" size="small">
+            small / bottom
+          </Button>
         </Tooltip>
       </div>
       <div className="flex items-center gap-20">
-        <Tooltip {...args}>
-          <div className="flex h-10 w-[240px] items-center justify-center rounded border border-gray-400">target</div>
+        <Tooltip content="内容説明テキスト" size="medium" verticalPosition="top">
+          <Button variant="outline" size="medium">
+            medium / top
+          </Button>
+        </Tooltip>
+        <Tooltip content="内容説明テキスト" size="medium" verticalPosition="bottom">
+          <Button variant="outline" size="medium">
+            medium / bottom
+          </Button>
         </Tooltip>
       </div>
     </div>
@@ -77,20 +83,88 @@ export const Base: Story = {
 };
 
 export const Portal: Story = {
-  args: {
-    portalTarget: document.body,
-    content: '内容説明テキスト',
-  },
-  render: (args) => (
-    <div className="grid gap-10 px-20 py-10">
+  render: () => (
+    <div className="flex flex-col gap-16 p-20">
       <div className="flex items-center gap-20">
-        <Tooltip {...args}>
-          <div className="flex h-10 w-24 items-center justify-center rounded border border-gray-400">target</div>
+        <Tooltip content="内容説明テキスト" size="small" horizontalAlign="left" portalTarget={document.body}>
+          <Button variant="outline" size="small">
+            small / left
+          </Button>
+        </Tooltip>
+        <Tooltip content="内容説明テキスト" size="small" horizontalAlign="center" portalTarget={document.body}>
+          <Button variant="outline" size="small">
+            small / center
+          </Button>
+        </Tooltip>
+        <Tooltip content="内容説明テキスト" size="small" horizontalAlign="right" portalTarget={document.body}>
+          <Button variant="outline" size="small">
+            small / right
+          </Button>
         </Tooltip>
       </div>
       <div className="flex items-center gap-20">
-        <Tooltip {...args}>
-          <div className="flex h-10 w-[240px] items-center justify-center rounded border border-gray-400">target</div>
+        <Tooltip content="内容説明テキスト" size="medium" horizontalAlign="left" portalTarget={document.body}>
+          <Button variant="outline" size="medium">
+            medium / left
+          </Button>
+        </Tooltip>
+        <Tooltip content="内容説明テキスト" size="medium" horizontalAlign="center" portalTarget={document.body}>
+          <Button variant="outline" size="medium">
+            medium / center
+          </Button>
+        </Tooltip>
+        <Tooltip content="内容説明テキスト" size="medium" horizontalAlign="right" portalTarget={document.body}>
+          <Button variant="outline" size="medium">
+            medium / right
+          </Button>
+        </Tooltip>
+      </div>
+    </div>
+  ),
+};
+
+export const WithMaxWidth: Story = {
+  render: () => (
+    <div className="flex flex-col gap-16 p-20">
+      <div className="flex items-center gap-20">
+        <Tooltip
+          content="とても長いツールチップの説明テキストで自動的に折り返されることを確認する"
+          size="small"
+          maxWidth={120}
+        >
+          <Button variant="outline" size="small">
+            small / maxWidth 120
+          </Button>
+        </Tooltip>
+        <Tooltip content="とても長いツールチップの説明テキストで折り返しが発生しない例" size="small">
+          <Button variant="outline" size="small">
+            small / maxWidth 未指定
+          </Button>
+        </Tooltip>
+      </div>
+      <div className="flex items-center gap-20">
+        <Tooltip
+          content="とても長いツールチップの説明テキストで自動的に折り返されることを確認する"
+          size="medium"
+          maxWidth={200}
+        >
+          <Button variant="outline" size="medium">
+            medium / maxWidth 200
+          </Button>
+        </Tooltip>
+        <Tooltip
+          content={
+            <>
+              改行を含む説明テキストの1行目
+              <br />
+              改行を含む説明テキストの2行目
+            </>
+          }
+          size="medium"
+        >
+          <Button variant="outline" size="medium">
+            medium / 改行content
+          </Button>
         </Tooltip>
       </div>
     </div>
@@ -106,20 +180,22 @@ export const Portal: Story = {
  * 2. target にホバーする
  * 3. Tooltip が target の直上（または直下）に表示されればOK
  */
-export const PortalWithInnerScroll: Story = {
+export const ReproInnerScroll: Story = {
   parameters: {
     chromatic: { disable: true },
   },
   render: () => (
-    <div className="px-20 py-10">
-      <p className="typography-body14regular mb-2 text-text02">
+    <div className="flex flex-col gap-2 px-20 py-10">
+      <p className="typography-body14regular text-text02">
         内側のコンテナをスクロールしてから target にホバーしてください。
       </p>
       <div className="h-[300px] w-[400px] overflow-y-auto border border-uiBorder01">
         <div className="h-[200px] bg-uiBackground02" />
         <div className="flex items-center justify-center p-4">
           <Tooltip content="内容説明テキスト" portalTarget={document.body} verticalPosition="top">
-            <div className="flex h-10 w-[240px] items-center justify-center rounded border border-gray-400">target</div>
+            <Button variant="outline" size="small">
+              ラベル
+            </Button>
           </Tooltip>
         </div>
         <div className="h-[600px] bg-uiBackground02" />
@@ -139,7 +215,7 @@ export const PortalWithInnerScroll: Story = {
  * 2. target にホバーする
  * 3. Tooltip が target の直上に表示されればOK
  */
-export const PortalWithLayoutShift: Story = {
+export const ReproLayoutShift: Story = {
   parameters: {
     chromatic: { disable: true },
   },
@@ -147,20 +223,16 @@ export const PortalWithLayoutShift: Story = {
     const [isWide, setIsWide] = useState(false);
 
     return (
-      <div className="px-20 py-10">
-        <p className="typography-body14regular mb-2 text-text02">
-          ボタンで幅を切り替えてから target にホバーしてください。
-        </p>
-        <button
-          type="button"
-          onClick={() => setIsWide((prev) => !prev)}
-          className="mb-4 rounded border border-uiBorder02 px-3 py-1 text-text01"
-        >
+      <div className="flex flex-col gap-2 px-20 py-10">
+        <p className="typography-body14regular text-text02">ボタンで幅を切り替えてから target にホバーしてください。</p>
+        <Button variant="outline" size="small" onClick={() => setIsWide((prev) => !prev)}>
           幅を切り替える（現在: {isWide ? 'wide' : 'narrow'}）
-        </button>
+        </Button>
         <div style={{ width: isWide ? 600 : 300 }} className="border border-uiBorder01 p-4">
           <Tooltip content="内容説明テキスト" portalTarget={document.body} verticalPosition="top">
-            <div className="flex h-10 w-full items-center justify-center rounded border border-gray-400">target</div>
+            <Button variant="outline" size="small">
+              ラベル
+            </Button>
           </Tooltip>
         </div>
       </div>
@@ -178,19 +250,21 @@ export const PortalWithLayoutShift: Story = {
  * 3. Tooltip が target の直上に表示されればOK
  * 4. さらにホバー中にスクロールしても追従することを確認
  */
-export const PortalWithWindowScroll: Story = {
+export const ReproWindowScroll: Story = {
   parameters: {
     chromatic: { disable: true },
   },
   render: () => (
-    <div className="px-20 py-10">
-      <p className="typography-body14regular mb-2 text-text02">
+    <div className="flex flex-col gap-2 px-20 py-10">
+      <p className="typography-body14regular text-text02">
         ページ全体をスクロールしてから target にホバーしてください。
       </p>
       <div className="h-[800px] bg-uiBackground02" />
       <div className="flex items-center justify-center py-4">
         <Tooltip content="内容説明テキスト" portalTarget={document.body} verticalPosition="top">
-          <div className="flex h-10 w-[240px] items-center justify-center rounded border border-gray-400">target</div>
+          <Button variant="outline" size="small">
+            ラベル
+          </Button>
         </Tooltip>
       </div>
       <div className="h-[800px] bg-uiBackground02" />

--- a/packages/component-ui/src/tooltip/tooltip.stories.tsx
+++ b/packages/component-ui/src/tooltip/tooltip.stories.tsx
@@ -223,7 +223,7 @@ export const ReproLayoutShift: Story = {
     const [isWide, setIsWide] = useState(false);
 
     return (
-      <div className="flex flex-col gap-2 px-20 py-10">
+      <div className="flex flex-col items-start gap-2 px-20 py-10">
         <p className="typography-body14regular text-text02">ボタンで幅を切り替えてから target にホバーしてください。</p>
         <Button variant="outline" size="small" onClick={() => setIsWide((prev) => !prev)}>
           幅を切り替える（現在: {isWide ? 'wide' : 'narrow'}）

--- a/packages/component-ui/src/tooltip/tooltip.stories.tsx
+++ b/packages/component-ui/src/tooltip/tooltip.stories.tsx
@@ -8,7 +8,7 @@ const meta: Meta<typeof Tooltip> = {
   title: 'Components/Tooltip',
   component: Tooltip,
   argTypes: {
-    size: { control: 'select', options: ['small', 'medium'] },
+    size: { control: 'radio', options: ['small', 'medium'] },
     verticalPosition: { control: 'radio', options: ['top', 'bottom'] },
     horizontalAlign: { control: 'radio', options: ['left', 'center', 'right'] },
     content: { control: 'text' },

--- a/packages/component-ui/src/tooltip/tooltip.stories.tsx
+++ b/packages/component-ui/src/tooltip/tooltip.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
 
 import { Tooltip } from './tooltip';
 
@@ -94,4 +95,75 @@ export const Portal: Story = {
       </div>
     </div>
   ),
+};
+
+/**
+ * `portalTarget` 指定時に、内部スクロール可能なコンテナ内で target 位置が変化した場合でも、
+ * ホバー時に正しい位置に Tooltip が表示されることを確認する再現用ストーリー。
+ *
+ * 確認手順:
+ * 1. 内側の灰色コンテナをスクロール
+ * 2. target にホバーする
+ * 3. Tooltip が target の直上（または直下）に表示されればOK
+ */
+export const PortalWithInnerScroll: Story = {
+  parameters: {
+    chromatic: { disable: true },
+  },
+  render: () => (
+    <div className="px-20 py-10">
+      <p className="typography-body14regular mb-2 text-text02">
+        内側のコンテナをスクロールしてから target にホバーしてください。
+      </p>
+      <div className="h-[300px] w-[400px] overflow-y-auto border border-uiBorder01">
+        <div className="h-[200px] bg-uiBackground02" />
+        <div className="flex items-center justify-center p-4">
+          <Tooltip content="内容説明テキスト" portalTarget={document.body} verticalPosition="top">
+            <div className="flex h-10 w-[240px] items-center justify-center rounded border border-gray-400">target</div>
+          </Tooltip>
+        </div>
+        <div className="h-[600px] bg-uiBackground02" />
+      </div>
+    </div>
+  ),
+};
+
+/**
+ * `portalTarget` 指定時に、親コンテナ幅が動的に変化した場合でも、
+ * ホバー時に正しい位置に Tooltip が表示されることを確認する再現用ストーリー。
+ *
+ * harutaka-workspace でドロワー開閉により table 幅が変わる挙動を簡易再現したもの。
+ *
+ * 確認手順:
+ * 1. トグルボタンで親コンテナの幅を変更
+ * 2. target にホバーする
+ * 3. Tooltip が target の直上に表示されればOK
+ */
+export const PortalWithLayoutShift: Story = {
+  parameters: {
+    chromatic: { disable: true },
+  },
+  render: function Render() {
+    const [isWide, setIsWide] = useState(false);
+
+    return (
+      <div className="px-20 py-10">
+        <p className="typography-body14regular mb-2 text-text02">
+          ボタンで幅を切り替えてから target にホバーしてください。
+        </p>
+        <button
+          type="button"
+          onClick={() => setIsWide((prev) => !prev)}
+          className="mb-4 rounded border border-uiBorder02 px-3 py-1 text-text01"
+        >
+          幅を切り替える（現在: {isWide ? 'wide' : 'narrow'}）
+        </button>
+        <div style={{ width: isWide ? 600 : 300 }} className="border border-uiBorder01 p-4">
+          <Tooltip content="内容説明テキスト" portalTarget={document.body} verticalPosition="top">
+            <div className="flex h-10 w-full items-center justify-center rounded border border-gray-400">target</div>
+          </Tooltip>
+        </div>
+      </div>
+    );
+  },
 };

--- a/packages/component-ui/src/tooltip/tooltip.stories.tsx
+++ b/packages/component-ui/src/tooltip/tooltip.stories.tsx
@@ -167,3 +167,33 @@ export const PortalWithLayoutShift: Story = {
     );
   },
 };
+
+/**
+ * `portalTarget` 指定時に、window 自体をスクロールした場合でも、
+ * Tooltip が target に追従することを確認する再現用ストーリー。
+ *
+ * 確認手順:
+ * 1. window をスクロール（ページを下方向に動かす）
+ * 2. target にホバーする
+ * 3. Tooltip が target の直上に表示されればOK
+ * 4. さらにホバー中にスクロールしても追従することを確認
+ */
+export const PortalWithWindowScroll: Story = {
+  parameters: {
+    chromatic: { disable: true },
+  },
+  render: () => (
+    <div className="px-20 py-10">
+      <p className="typography-body14regular mb-2 text-text02">
+        ページ全体をスクロールしてから target にホバーしてください。
+      </p>
+      <div className="h-[800px] bg-uiBackground02" />
+      <div className="flex items-center justify-center py-4">
+        <Tooltip content="内容説明テキスト" portalTarget={document.body} verticalPosition="top">
+          <div className="flex h-10 w-[240px] items-center justify-center rounded border border-gray-400">target</div>
+        </Tooltip>
+      </div>
+      <div className="h-[800px] bg-uiBackground02" />
+    </div>
+  ),
+};


### PR DESCRIPTION
> [!NOTE]
> - Storybookの Story（Repro Inner Scroll と、Repro Inner Shift ）で不具合が発生している様子を確認できます。

## Summary

`Tooltip` コンポーネントの Storybook を改善しました。併せて `portalTarget` 指定時の挙動確認用の再現ストーリーも追加しています。

## Changes

### argTypes 拡充
- `content` / `maxWidth` / `isDisabledHover` に control を追加
- `portalTarget` / `children` は `control: false` で Controls 非表示
- `size` / `verticalPosition` / `horizontalAlign` を `radio` に変更

### ストーリー整理

| Story | 種類 | 変更 |
|---|---|---|
| `Component` | args 駆動 | target を `Button` に統一 |
| `Base` | render 固定 (VRT 対象) | size × verticalPosition マトリクスへ再構成 |
| `Portal` | render 固定 (VRT 対象) | size × horizontalAlign マトリクスへ再構成 |
| `WithMaxWidth` | render 固定 (VRT 対象) | 新規。`maxWidth` 指定/未指定 × 長文/改行 content の折り返し網羅 |
| `ReproInnerScroll` | 再現 (VRT 対象外) | `PortalWithInnerScroll` からリネーム + layout 整理 |
| `ReproLayoutShift` | 再現 (VRT 対象外) | `PortalWithLayoutShift` からリネーム + layout 整理 |
| `ReproWindowScroll` | 再現 (VRT 対象外) | `PortalWithWindowScroll` からリネーム + layout 整理 |

### ダミー target 排除
- `<div>target</div>` を `<Button variant="outline">ラベル</Button>` に置き換え（ガイドライン `docs/storybook-guidelines.md:449` 準拠）

### Layout 統一
- `mt-*` / `mb-*` を `flex flex-col gap-*` に統一（ガイドライン `docs/storybook-guidelines.md:450` 準拠）

## 既知の制約（別 PR で対応予定）

`Tooltip` 本体は hover 時のみ表示されるため、`Base` / `Portal` / `WithMaxWidth` の VRT スナップショットでは trigger のみ映ります。tooltip 配置ロジック自体の VRT カバレッジは本 PR では得られません。

→ 続編 PR で `play` function (`userEvent.hover`) により hover 後状態を固定し、Chromatic で tooltip 本体の配置も確認できるようにする予定です。

## Test plan

- [x] `yarn type-check`
- [x] `npx eslint packages/component-ui/src/tooltip/tooltip.stories.tsx`
- [x] `npx prettier --check packages/component-ui/src/tooltip/tooltip.stories.tsx`
- [x] `yarn test:ci`: 全テスト通過
- [ ] Storybook で以下を目視確認
  - `Components/Tooltip/Component` の Controls で全 prop が操作できること
  - `Base` / `Portal` / `WithMaxWidth` のマトリクスが正しく並ぶこと
  - `ReproInnerScroll` / `ReproLayoutShift` / `ReproWindowScroll` で hover 中のスクロール/レイアウト変化時に Tooltip が追従すること

## Storybook

- Components/Tooltip/Component
- Components/Tooltip/Base
- Components/Tooltip/Portal
- Components/Tooltip/WithMaxWidth
- Components/Tooltip/ReproInnerScroll
- Components/Tooltip/ReproLayoutShift
- Components/Tooltip/ReproWindowScroll
