### PR TITLE
303｜fix(Tooltip): recalculate position on hover to avoid stale coordinates

### DIFF
--- a/docs/component/tooltip-specification.md
+++ b/docs/component/tooltip-specification.md
@@ -177,6 +177,7 @@ const PortalTooltip = () => (
 - `Tooltip` は内部で `useState` により `isVisible` を保持し、`onMouseOver`/`onMouseLeave` で開閉を切り替える。制御用のAPIは提供していない。
 - 表示座標は `useTooltip` フックの `calculatePosition` で算出する。`DOMRect` からターゲットの中心/端を求め、`horizontalAlign` と `verticalPosition` に応じて `left/top/bottom/translate` を定義する。
 - `window.scrollY` を参照してページスクロール分を補正し、ポータル描画時にも正しいY座標を確保する。
+- 位置計算は (1) props (`maxWidth` / `size` / `verticalPosition` / `horizontalAlign`) 変更時、(2) ホバー開始時、(3) 表示中の `scroll` / `resize` イベント発火時の3つのタイミングで実行する。表示中は `window` に `scroll` (`capture: true, passive: true`) と `resize` のリスナーを登録し、ドロワー開閉・内部スクロール・ウィンドウリサイズなどで target の位置が変わっても Tooltip が追従するようにしている。非表示時はリスナーを解除する。
 - `TooltipContent` は `isPortal` フラグで分岐し、ポータル時のみ `style` に `transform: translate(...)` と算出済み座標をマージする。
 - `TailIcon` はサイズ別のSVGを返し、`clsx` で上下左右のオフセットを切り替えることで常に吹き出しの端点とトリガーが繋がるように実装している。
 
@@ -188,7 +189,8 @@ const PortalTooltip = () => (
 ## 注意事項
 
 - Tooltipはホバー中のみ一時的に表示されるため、ユーザーが情報を保持できない。入力必須項目や警告など、恒常表示が必要な情報を配置してはならない。
-- サイズ計算は`useEffect`で `maxWidth`, `size`, `verticalPosition`, `horizontalAlign` が変化した時のみ再計算される。ターゲットが動的にサイズ変更される場合は再レンダーを行い計算を更新すること。
+- 位置計算は props 変更時に加え、ホバー開始時と表示中の `scroll` / `resize` で自動的に再計算される。レイアウト変化後や表示中のスクロールにも追従するため、呼び出し側で明示的に再計算をトリガーする必要はない。
+- 位置計算はグローバルの `window.scrollY` / `window.scrollX` に依存する。ページ全体とは別の document を持つ iframe 内など、独自の document を portal 先に指定するケースは想定していない。
 - `portalTarget` 未指定で `overflow: hidden` な親要素内に配置した場合、Tooltipが切り取られる。必要に応じてポータル先を指定する。
 
 ## スタイルのカスタマイズ
@@ -199,6 +201,7 @@ const PortalTooltip = () => (
 
 ## 更新履歴
 
-| 日付                 | 内容                                                     | 担当者 |
-| -------------------- | -------------------------------------------------------- | ------ |
-| 2025-12-03 09:23 JST | Tooltip仕様書を新規作成し、Props/使用例/注意事項を整理。 | -      |
+| 日付                 | 内容                                                                                             | 担当者 |
+| -------------------- | ------------------------------------------------------------------------------------------------ | ------ |
+| 2025-12-03 09:23 JST | Tooltip仕様書を新規作成し、Props/使用例/注意事項を整理。                                         | -      |
+| 2026-04-14 15:30 JST | ホバー開始時と表示中の `scroll` / `resize` で位置を再計算する挙動を追加し、実装/注意事項に反映。 | -      |

--- a/packages/component-ui/src/tooltip/tooltip.test.tsx
+++ b/packages/component-ui/src/tooltip/tooltip.test.tsx
@@ -1,0 +1,166 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { Tooltip } from './tooltip';
+
+describe('Tooltip', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('レンダリング', () => {
+    it('children が描画される', () => {
+      render(
+        <Tooltip content="tooltip-content">
+          <button type="button">trigger</button>
+        </Tooltip>,
+      );
+
+      expect(screen.getByRole('button', { name: 'trigger' })).toBeInTheDocument();
+    });
+
+    it('初期状態では content は描画されない', () => {
+      render(
+        <Tooltip content="tooltip-content">
+          <button type="button">trigger</button>
+        </Tooltip>,
+      );
+
+      expect(screen.queryByText('tooltip-content')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('ホバー表示', () => {
+    it('ホバーすると content が表示される', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <Tooltip content="tooltip-content">
+          <button type="button">trigger</button>
+        </Tooltip>,
+      );
+
+      await user.hover(screen.getByRole('button', { name: 'trigger' }));
+
+      expect(screen.getByText('tooltip-content')).toBeInTheDocument();
+    });
+
+    it('ホバー解除で content が非表示になる', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <Tooltip content="tooltip-content">
+          <button type="button">trigger</button>
+        </Tooltip>,
+      );
+
+      const trigger = screen.getByRole('button', { name: 'trigger' });
+      await user.hover(trigger);
+      expect(screen.getByText('tooltip-content')).toBeInTheDocument();
+
+      await user.unhover(trigger);
+      expect(screen.queryByText('tooltip-content')).not.toBeInTheDocument();
+    });
+
+    it('isDisabledHover が true のときホバーしても表示されない', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <Tooltip content="tooltip-content" isDisabledHover>
+          <button type="button">trigger</button>
+        </Tooltip>,
+      );
+
+      await user.hover(screen.getByRole('button', { name: 'trigger' }));
+
+      expect(screen.queryByText('tooltip-content')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('portalTarget', () => {
+    it('portalTarget 指定時、指定した要素配下に content が描画される', async () => {
+      const user = userEvent.setup();
+      const portalTarget = document.createElement('div');
+      portalTarget.setAttribute('data-testid', 'portal-root');
+      document.body.appendChild(portalTarget);
+
+      render(
+        <Tooltip content="tooltip-content" portalTarget={portalTarget}>
+          <button type="button">trigger</button>
+        </Tooltip>,
+      );
+
+      await user.hover(screen.getByRole('button', { name: 'trigger' }));
+
+      const portalRoot = screen.getByTestId('portal-root');
+      expect(portalRoot).toContainElement(screen.getByText('tooltip-content'));
+
+      document.body.removeChild(portalTarget);
+    });
+  });
+
+  describe('位置再計算', () => {
+    it('ホバーのたびに getBoundingClientRect が呼ばれて位置が再計算される', async () => {
+      const user = userEvent.setup();
+      const getBoundingClientRectSpy = vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect');
+
+      render(
+        <Tooltip content="tooltip-content" portalTarget={document.body}>
+          <button type="button">trigger</button>
+        </Tooltip>,
+      );
+
+      const initialCallCount = getBoundingClientRectSpy.mock.calls.length;
+      const trigger = screen.getByRole('button', { name: 'trigger' });
+
+      await user.hover(trigger);
+      const firstHoverCallCount = getBoundingClientRectSpy.mock.calls.length;
+      expect(firstHoverCallCount).toBeGreaterThan(initialCallCount);
+
+      await user.unhover(trigger);
+      await user.hover(trigger);
+      expect(getBoundingClientRectSpy.mock.calls.length).toBeGreaterThan(firstHoverCallCount);
+    });
+
+    it('スクロール後のホバーで最新の座標に基づいて位置が計算される', async () => {
+      const user = userEvent.setup();
+
+      const makeRect = (top: number): DOMRect =>
+        ({
+          top,
+          bottom: top + 40,
+          left: 0,
+          right: 100,
+          width: 100,
+          height: 40,
+          x: 0,
+          y: top,
+          toJSON: () => ({}),
+        }) as DOMRect;
+
+      const queue: DOMRect[] = [makeRect(100), makeRect(100), makeRect(20)];
+      vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(() => {
+        return queue.shift() ?? makeRect(20);
+      });
+
+      render(
+        <Tooltip content="tooltip-content" portalTarget={document.body} verticalPosition="bottom">
+          <button type="button">trigger</button>
+        </Tooltip>,
+      );
+
+      const trigger = screen.getByRole('button', { name: 'trigger' });
+
+      await user.hover(trigger);
+      const firstTop = screen.getByText('tooltip-content').parentElement?.style.top;
+      expect(firstTop).toBeDefined();
+
+      await user.unhover(trigger);
+      await user.hover(trigger);
+      const secondTop = screen.getByText('tooltip-content').parentElement?.style.top;
+
+      expect(secondTop).not.toEqual(firstTop);
+    });
+  });
+});

--- a/packages/component-ui/src/tooltip/tooltip.test.tsx
+++ b/packages/component-ui/src/tooltip/tooltip.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -161,6 +161,100 @@ describe('Tooltip', () => {
       const secondTop = screen.getByText('tooltip-content').parentElement?.style.top;
 
       expect(secondTop).not.toEqual(firstTop);
+    });
+
+    it('表示中のスクロールで位置が追従する', async () => {
+      const user = userEvent.setup();
+
+      const makeRect = (top: number): DOMRect =>
+        ({
+          top,
+          bottom: top + 40,
+          left: 0,
+          right: 100,
+          width: 100,
+          height: 40,
+          x: 0,
+          y: top,
+          toJSON: () => ({}),
+        }) as DOMRect;
+
+      const queue: DOMRect[] = [makeRect(100), makeRect(100), makeRect(20)];
+      vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(() => {
+        return queue.shift() ?? makeRect(20);
+      });
+
+      render(
+        <Tooltip content="tooltip-content" portalTarget={document.body} verticalPosition="bottom">
+          <button type="button">trigger</button>
+        </Tooltip>,
+      );
+
+      await user.hover(screen.getByRole('button', { name: 'trigger' }));
+      const initialTop = screen.getByText('tooltip-content').parentElement?.style.top;
+
+      await act(async () => {
+        window.dispatchEvent(new Event('scroll'));
+      });
+
+      const updatedTop = screen.getByText('tooltip-content').parentElement?.style.top;
+      expect(updatedTop).not.toEqual(initialTop);
+    });
+
+    it('表示中のリサイズで位置が追従する', async () => {
+      const user = userEvent.setup();
+
+      const makeRect = (top: number): DOMRect =>
+        ({
+          top,
+          bottom: top + 40,
+          left: 0,
+          right: 100,
+          width: 100,
+          height: 40,
+          x: 0,
+          y: top,
+          toJSON: () => ({}),
+        }) as DOMRect;
+
+      const queue: DOMRect[] = [makeRect(100), makeRect(100), makeRect(20)];
+      vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(() => {
+        return queue.shift() ?? makeRect(20);
+      });
+
+      render(
+        <Tooltip content="tooltip-content" portalTarget={document.body} verticalPosition="bottom">
+          <button type="button">trigger</button>
+        </Tooltip>,
+      );
+
+      await user.hover(screen.getByRole('button', { name: 'trigger' }));
+      const initialTop = screen.getByText('tooltip-content').parentElement?.style.top;
+
+      await act(async () => {
+        window.dispatchEvent(new Event('resize'));
+      });
+
+      const updatedTop = screen.getByText('tooltip-content').parentElement?.style.top;
+      expect(updatedTop).not.toEqual(initialTop);
+    });
+
+    it('非表示時にスクロールしても再計算されない', async () => {
+      const getBoundingClientRectSpy = vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect');
+
+      render(
+        <Tooltip content="tooltip-content" portalTarget={document.body}>
+          <button type="button">trigger</button>
+        </Tooltip>,
+      );
+
+      const callCountBeforeScroll = getBoundingClientRectSpy.mock.calls.length;
+
+      await act(async () => {
+        window.dispatchEvent(new Event('scroll'));
+      });
+
+      expect(getBoundingClientRectSpy.mock.calls.length).toBe(callCountBeforeScroll);
     });
   });
 });

--- a/packages/component-ui/src/tooltip/tooltip.tsx
+++ b/packages/component-ui/src/tooltip/tooltip.tsx
@@ -57,8 +57,20 @@ export function Tooltip({
     if (isDisabledHover) {
       return;
     }
+    if (targetRef.current !== null) {
+      const dimensions = targetRef.current.getBoundingClientRect();
+      const position = calculatePosition({
+        dimensions,
+        maxWidth,
+        verticalPosition,
+        horizontalAlign,
+        tooltipSize: size,
+      });
+
+      setTooltipPosition(position);
+    }
     setIsVisible(true);
-  }, [isDisabledHover]);
+  }, [isDisabledHover, calculatePosition, maxWidth, verticalPosition, horizontalAlign, size]);
 
   const handleMouseOutWrapper = useCallback(() => {
     setIsVisible(false);

--- a/packages/component-ui/src/tooltip/tooltip.tsx
+++ b/packages/component-ui/src/tooltip/tooltip.tsx
@@ -85,6 +85,32 @@ export function Tooltip({
     setTooltipPosition(position);
   }, [calculatePosition, horizontalAlign, maxWidth, size, verticalPosition]);
 
+  useEffect(() => {
+    if (!isVisible) return;
+
+    const updatePosition = () => {
+      if (targetRef.current === null) return;
+      const dimensions = targetRef.current.getBoundingClientRect();
+      const position = calculatePosition({
+        dimensions,
+        maxWidth,
+        verticalPosition,
+        horizontalAlign,
+        tooltipSize: size,
+      });
+
+      setTooltipPosition(position);
+    };
+
+    window.addEventListener('scroll', updatePosition, { capture: true, passive: true });
+    window.addEventListener('resize', updatePosition, { passive: true });
+
+    return () => {
+      window.removeEventListener('scroll', updatePosition, { capture: true });
+      window.removeEventListener('resize', updatePosition);
+    };
+  }, [isVisible, calculatePosition, maxWidth, verticalPosition, horizontalAlign, size]);
+
   return (
     <div
       ref={targetRef}


### PR DESCRIPTION
> [!NOTE]
> - このPRは #570 にスタックしています。

> [!NOTE]
> - Storybookの Story（Repro Inner Scroll と、Repro Inner Shift ）で不具合の修正を動作確認ができます。
> - 修正前の様子は、 https://github.com/zenkigen/zenkigen-component/pull/570 の Story（Repro Inner Scroll と、Repro Inner Shift ）で確認できます（不具合が発生している様子を確認できる）。

## Summary

`portalTarget` 指定時、初回マウント時に取得した `getBoundingClientRect()` の値で位置計算が固定化され、target の座標やレイアウトが変化した後のホバーで Tooltip が正しくない位置に表示される問題を修正しました。

## 問題

`tooltip.tsx` の `useEffect` が `isVisible` を依存に含んでいないため、初回マウント時の座標のまま固定化される。特に `portalTarget={document.body}` 指定時はビューポート座標ベースの `top/left` を `style` に直接適用するため、以下のケースで位置ズレが顕在化:

- 内部スクロール可能なコンテナがスクロールされた後
- 親コンテナ幅などレイアウトが動的に変化した後（例: ドロワー開閉、resize）
- target が非同期レンダリングで後から表示された場合

## 対応

### 1. ホバー時に位置を再計算

`handleMouseOverWrapper` 内でホバー瞬間に `getBoundingClientRect()` を取り直して `calculatePosition` を呼び出し、最新のレイアウトに追従するようにした。既存の `useEffect` は props 変更時の初期計算として残す（最小差分）。

```diff
  const handleMouseOverWrapper = useCallback(() => {
    if (isDisabledHover) {
      return;
    }
+   if (targetRef.current !== null) {
+     const dimensions = targetRef.current.getBoundingClientRect();
+     const position = calculatePosition({ dimensions, maxWidth, verticalPosition, horizontalAlign, tooltipSize: size });
+     setTooltipPosition(position);
+   }
    setIsVisible(true);
- }, [isDisabledHover]);
+ }, [isDisabledHover, calculatePosition, maxWidth, verticalPosition, horizontalAlign, size]);
```

### 2. 表示中のスクロール/リサイズに追従

`isVisible === true` の間、`window` に `scroll` (capture: true, passive: true) / `resize` リスナーを登録し、target 位置を常に再計算するようにした。これで hover 中にページがスクロールされても Tooltip が target に追従する。

- `capture: true` で祖先コンテナの内部スクロールも拾う
- `passive: true` でスクロール性能への影響を最小化
- 非表示時はリスナー解除済みで再計算コストなし

## スコープ外（別 issue 推奨）

- `tooltip-hook.ts` の水平スクロール対応（`left` 計算に `window.scrollX` が抜けている）
- 別 window / iframe / 特殊な portalTarget への対応

## Test plan

- [x] 新規テストファイル `tooltip.test.tsx` を追加（11 テスト、全通過）
  - レンダリング、ホバー表示、`isDisabledHover`、portal 描画
  - ホバー毎の位置再計算
  - 表示中のスクロール/リサイズで追従
  - 非表示時はリスナーなし
- [x] `yarn test:ci`: 全 427 テスト通過
- [x] `yarn type-check`
- [x] `npx eslint packages/component-ui/src/tooltip/`
- [ ] Storybook で手動確認（#570 のストーリーを使用）
  - `Components/Tooltip/ReproInnerScroll` でスクロール後のホバー位置が target に追従すること
  - `Components/Tooltip/ReproLayoutShift` で幅切り替え後のホバー位置が target に追従すること
  - `Components/Tooltip/ReproWindowScroll` で window スクロール後のホバー位置が target に追従すること
