### PR TITLE
fix(useOutsideClick): close other floating elements when toggle re-renders detach the target

### DIFF
--- a/packages/component-ui/src/combobox/combobox.test.tsx
+++ b/packages/component-ui/src/combobox/combobox.test.tsx
@@ -199,6 +199,29 @@ describe('Combobox', () => {
       await user.click(screen.getByRole('button', { name: 'outside' }));
       expect(getListbox()).toHaveStyle({ visibility: 'hidden' });
     });
+
+    it('別の Combobox のトグルを押すと、先に開いていた Combobox が閉じる', async () => {
+      const user = userEvent.setup();
+      render(
+        <div>
+          <ControlledCombobox />
+          <ControlledCombobox />
+        </div>,
+      );
+      const inputs = screen.getAllByRole('combobox') as HTMLInputElement[];
+      const listboxes = screen.getAllByRole('listbox', { hidden: true });
+      const toggles = screen.getAllByRole('button', { name: '候補を表示' });
+
+      await user.click(toggles[0]!);
+      expect(inputs[0]).toHaveAttribute('aria-expanded', 'true');
+      expect(listboxes[0]).toHaveStyle({ visibility: 'visible' });
+
+      await user.click(toggles[1]!);
+      expect(inputs[0]).toHaveAttribute('aria-expanded', 'false');
+      expect(listboxes[0]).toHaveStyle({ visibility: 'hidden' });
+      expect(inputs[1]).toHaveAttribute('aria-expanded', 'true');
+      expect(listboxes[1]).toHaveStyle({ visibility: 'visible' });
+    });
   });
 
   describe('選択動作', () => {

--- a/packages/component-ui/src/combobox/combobox.test.tsx
+++ b/packages/component-ui/src/combobox/combobox.test.tsx
@@ -229,6 +229,32 @@ describe('Combobox', () => {
       expect(inputs[1]).toHaveAttribute('aria-expanded', 'true');
       expect(listboxes[1]).toHaveStyle({ visibility: 'visible' });
     });
+
+    // useOutsideClick の `isConnected` 早期 return を廃止したことで最も再発を警戒すべきは、
+    // 「自身のトグル押下時に icon の svg が再レンダリングで detach され、誤って外部クリック扱いになり
+    // 開いた直後に閉じてしまう」回帰（過去に PR #543 で `isConnected` を入れて直したバグ）。
+    // composedPath による内側判定でこれが防がれていることを結合レベルで担保する。
+    // （フック単体の本質的ガードは `hooks/use-outside-click.test.tsx` 側）
+    it('自身のトグルを押すと開閉が交互に切り替わり、開いた直後に即閉じしない', async () => {
+      const user = userEvent.setup();
+      render(<ControlledCombobox />);
+      const input = getCombobox();
+
+      // 1回目: トグルで open し、外部クリック誤検出で即閉じしないこと
+      await user.click(screen.getByRole('button', { name: '候補を表示' }));
+      expect(input).toHaveAttribute('aria-expanded', 'true');
+      expect(getListbox()).toHaveStyle({ visibility: 'visible' });
+
+      // 2回目: トグルで close すること
+      await user.click(screen.getByRole('button', { name: '候補を閉じる' }));
+      expect(input).toHaveAttribute('aria-expanded', 'false');
+      expect(getListbox()).toHaveStyle({ visibility: 'hidden' });
+
+      // 3回目: 再度トグルで open でき、繰り返しトグル可能なこと
+      await user.click(screen.getByRole('button', { name: '候補を表示' }));
+      expect(input).toHaveAttribute('aria-expanded', 'true');
+      expect(getListbox()).toHaveStyle({ visibility: 'visible' });
+    });
   });
 
   describe('選択動作', () => {

--- a/packages/component-ui/src/combobox/combobox.test.tsx
+++ b/packages/component-ui/src/combobox/combobox.test.tsx
@@ -200,6 +200,13 @@ describe('Combobox', () => {
       expect(getListbox()).toHaveStyle({ visibility: 'hidden' });
     });
 
+    // これは「複数 Combobox を並べて他方のトグルを押すと先に開いた側が閉じる」という
+    // ユーザー観点の正常系シナリオの確認。
+    // useOutsideClick の `isConnected` 早期 return 廃止に伴う回帰
+    //（再レンダリングで target が detach されたときの内側/外側判定）の本質的なガードは
+    // `hooks/use-outside-click.test.tsx` のフック単体テストが担う。
+    // jsdom + userEvent の同期ディスパッチでは svg の detach が再現されないため、
+    // この統合テスト単体ではバグの再現はできない点に注意。
     it('別の Combobox のトグルを押すと、先に開いていた Combobox が閉じる', async () => {
       const user = userEvent.setup();
       render(

--- a/packages/component-ui/src/hooks/use-outside-click.test.tsx
+++ b/packages/component-ui/src/hooks/use-outside-click.test.tsx
@@ -132,4 +132,51 @@ describe('useOutsideClick', () => {
 
     document.body.removeChild(container);
   });
+
+  // bubbling 中に target が detach されるケース。
+  // 実環境では「ref 内のトグル ボタン押下 → React 再レンダリングで子の svg が unmount」のように、
+  // クリック処理中に target が DOM から切り離される。
+  // composedPath にはイベント発火時点の祖先が保持されるので、それを使って内側/外側を判定する必要がある。
+  describe('bubbling 中に target が DOM から切り離されるケース', () => {
+    it('ref 内部の要素を target にした click が bubbling 中に detach されても、composedPath で内側判定され handler が呼ばれないこと', () => {
+      const handler = vi.fn();
+      const container = document.createElement('div');
+      const button = document.createElement('button');
+      const span = document.createElement('span');
+      button.appendChild(span);
+      container.appendChild(button);
+      document.body.appendChild(container);
+
+      renderHook(() => useOutsideClick(createRef(container), handler));
+
+      // bubbling 中に target を detach する
+      span.addEventListener('click', () => span.remove(), { once: true });
+      span.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }));
+
+      expect(handler).not.toHaveBeenCalled();
+
+      document.body.removeChild(container);
+    });
+
+    it('ref 外部の要素を target にした click が bubbling 中に detach されても、composedPath が ref を含まなければ handler が呼ばれること', () => {
+      const handler = vi.fn();
+      const container = document.createElement('div');
+      const outsideWrapper = document.createElement('div');
+      const span = document.createElement('span');
+      outsideWrapper.appendChild(span);
+      document.body.appendChild(container);
+      document.body.appendChild(outsideWrapper);
+
+      renderHook(() => useOutsideClick(createRef(container), handler));
+
+      // bubbling 中に target を detach する
+      span.addEventListener('click', () => span.remove(), { once: true });
+      span.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }));
+
+      expect(handler).toHaveBeenCalledTimes(1);
+
+      document.body.removeChild(container);
+      document.body.removeChild(outsideWrapper);
+    });
+  });
 });

--- a/packages/component-ui/src/hooks/use-outside-click.ts
+++ b/packages/component-ui/src/hooks/use-outside-click.ts
@@ -9,15 +9,26 @@ export const useOutsideClick = <T extends HTMLElement = HTMLElement>(
   useEffect(() => {
     const listener = (event: Event) => {
       const element = ref?.current;
+      if (element == null) {
+        return;
+      }
+
       const target = event.target as Node | null;
-      // Reactの再レンダリングで要素が置換されDOMから切り離された場合は外部クリックと判定しない
-      if (target instanceof Node && target.isConnected === false) {
+      // ref要素内のクリックは外部クリックと判定しない
+      if (target != null && Boolean(element.contains(target))) {
         return;
       }
-      // ref要素内のクリック、またはrefが未設定の場合は外部クリックと判定しない
-      if (element == null || Boolean(element.contains(target ?? null))) {
+
+      // Reactの再レンダリングで target がDOMから切り離されているケースに備え、
+      // composedPath にイベント発火時点の祖先要素が残っているため、それを使って内側判定する。
+      // これにより自身のトグル ボタン押下で icon の svg が再生成されるケースを内側として扱いつつ、
+      // 他のフローティング要素のトグルを押した場合は外部クリックとして判定できる。
+      const path = typeof event.composedPath === 'function' ? event.composedPath() : [];
+      const isInsideViaPath = path.some((node) => node instanceof Node && Boolean(element.contains(node)));
+      if (isInsideViaPath) {
         return;
       }
+
       handler(event);
     };
 

--- a/packages/component-ui/src/hooks/use-outside-click.ts
+++ b/packages/component-ui/src/hooks/use-outside-click.ts
@@ -13,9 +13,10 @@ export const useOutsideClick = <T extends HTMLElement = HTMLElement>(
         return;
       }
 
-      const target = event.target as Node | null;
+      const target = event.target;
       // ref要素内のクリックは外部クリックと判定しない
-      if (target != null && Boolean(element.contains(target))) {
+      // contains() の戻り値は strict-boolean-expressions 対策で Boolean() で明示変換する
+      if (target instanceof Node && Boolean(element.contains(target))) {
         return;
       }
 


### PR DESCRIPTION
> [!NOTE]
> この PR は `feat/combobox-list` にスタックしています。base が `feat/combobox-list` のため、先に親 PR をマージしてからこちらを `main` にリベースしてください。

## 概要

複数の Combobox（または Select / Dropdown / SelectSort）が並んでいるとき、片方を開いた状態でもう片方のトグルを押しても先に開いていた側が閉じない不具合を修正しました。`useOutsideClick` の判定ロジックを `composedPath()` ベースに変更し、再レンダリングで target が DOM から切り離されているケースでも内側 / 外側を正しく判定できるようにしています。

## 問題

複数の Combobox が並んでいる画面（Storybook の `Components/Combobox/Text` など）で次の操作をすると、先に開いていた Combobox が閉じない。

1. Combobox 1 のトグル（矢印アイコン）をクリックしてリストを開く
2. Combobox 2 のトグルをクリックしてリストを開く
3. **不具合**: Combobox 1 のリストが開いたまま残る

同じ `useOutsideClick` を共有している Select / Dropdown / SelectSort でも同種の現象が発生していました。

## 原因

`useOutsideClick` の早期 return ロジック（`target.isConnected === false` のとき何もしない）が、自身のトグル押下と他のフローティング要素のトグル押下を区別できていませんでした。

発火シーケンス:

1. Combobox 1 が開いている
2. Combobox 2 のトグル（`IconButton`）をクリック
3. `handleToggle` が `setIsOpen(true)` → React の同期再レンダリング
4. `IconButton` の `icon` が `angle-down` → `angle-up` に切り替わり、内部の `<svg>` が unmount/remount される
5. document の click listener 発火時には `event.target`（元の svg/path）は detach 済み
6. `target.isConnected === false` で早期 return → **Combobox 1 の handler が呼ばれず閉じない**

過去 commit `dcd7553a` で「自身のトグル時に icon の svg が detach され、誤って外部クリック扱いになって閉じる」別バグを直すために `isConnected` チェックが入りましたが、自身か他人かを区別しないため本件の副作用を生んでいました。

## 修正内容

`event.composedPath()` を使って祖先要素から内側 / 外側を判定するように変更しました。`composedPath()` には dispatch 時点の DOM 経路が保持されるため、target が detach されていても祖先の `<button>` / wrapper `<div>` から正しく判定できます。

```ts
const listener = (event: Event) => {
  const element = ref?.current;
  if (element == null) return;

  const target = event.target as Node | null;
  if (target != null && Boolean(element.contains(target))) return;

  // target が再レンダリングで detach されていても、composedPath に祖先が残っていれば内側判定
  const path = typeof event.composedPath === 'function' ? event.composedPath() : [];
  const isInsideViaPath = path.some((node) => node instanceof Node && Boolean(element.contains(node)));
  if (isInsideViaPath) return;

  handler(event);
};
```

判定の流れ:

- **自身のトグル押下**: target は detach 済み svg/path だが、composedPath には自身の wrapper が含まれる → 内側判定で handler skip（既存仕様維持）
- **他のフローティング要素のトグル押下**: target も composedPath も自身の wrapper を含まない → handler 呼び出しで `setIsOpen(false)`（**バグ修正**）
- **完全に外側のクリック**: 既存仕様維持

### 変更ファイル

| ファイル | 内容 |
|---|---|
| `packages/component-ui/src/hooks/use-outside-click.ts` | `isConnected` 早期 return を削除し、`composedPath()` ベースの内側判定に変更 |
| `packages/component-ui/src/hooks/use-outside-click.test.tsx` | bubbling 中に target が detach されるケース 2 件を追加（内側 / 外側） |
| `packages/component-ui/src/combobox/combobox.test.tsx` | 「別の Combobox のトグルを押すと、先に開いていた Combobox が閉じる」を追加 |

## 影響範囲

`useOutsideClick` を使う全コンポーネントに波及。修正により以下の利用箇所すべてで同種の不具合が解消されます。

- `Combobox`（本件で再現確認）
- `Select`
- `Dropdown`
- `SelectSort`

破壊的変更はありません（公開 API は変更なし、フックの型シグネチャも維持）。

## テスト観点

`use-outside-click.test.tsx` に追加した 2 ケースで本件の本質を担保。

- **「修正前 fail / 修正後 pass」のキー**: ref 外部の要素を target にした click が bubbling 中に detach されたとき、composedPath が ref を含まない場合は handler が呼ばれること（外部クリック判定）
- **既存仕様の維持**: ref 内部の要素を target にした click が bubbling 中に detach されても、composedPath で内側判定されて handler が呼ばれないこと

`combobox.test.tsx` には統合的な動作保証として「別の Combobox のトグルを押すと先に開いていた Combobox が閉じる」を追加。

## テスト手順

- [ ] `yarn storybook` で `Components / Combobox / Text` を開き、複数の Combobox の片方を開いてからもう片方のトグルを押す。先に開いていた Combobox が閉じることを確認
- [ ] `Components / Select` の story でも同様に複数 Select を並べた状態で他方のトグル押下時に閉じることを確認
- [ ] `Components / Dropdown` でも同様に確認
- [ ] 単独の Combobox / Select / Dropdown / SelectSort で、自身のトグルや外部クリックで正しく閉じる従来挙動が維持されていることを確認

## 実行したコマンド

- `yarn build:all` — OK
- `yarn lint` — OK（ESLint エラー 0 件）
- `yarn type-check` — OK
- `yarn test:ci` — 全テスト通過（519 件 / 2 skipped）
