### PR TITLE
287｜feat(modal): dismiss outer floating UIs on modal open

### DIFF
--- a/packages/component-ui/src/date-picker/date-picker.test.tsx
+++ b/packages/component-ui/src/date-picker/date-picker.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
+import { MODAL_OPEN_EVENT } from '../hooks/use-dismiss-on-modal-open';
 import { DatePicker } from './date-picker';
 
 const openPopover = async (user: ReturnType<typeof userEvent.setup>) => {
@@ -134,6 +135,22 @@ describe('DatePicker', () => {
       await user.keyboard('{Escape}');
 
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    it('Modal が開かれたイベントを受けると Popover が閉じること', async () => {
+      const user = userEvent.setup();
+      render(<DatePicker value={null} onChange={vi.fn()} />);
+
+      await openPopover(user);
+      expect(screen.getByRole('dialog', { name: '日付選択' })).toBeInTheDocument();
+
+      act(() => {
+        window.dispatchEvent(new CustomEvent(MODAL_OPEN_EVENT));
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByRole('dialog', { name: '日付選択' })).not.toBeInTheDocument();
+      });
     });
   });
 

--- a/packages/component-ui/src/dropdown/dropdown.test.tsx
+++ b/packages/component-ui/src/dropdown/dropdown.test.tsx
@@ -1,0 +1,32 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { MODAL_OPEN_EVENT } from '../hooks/use-dismiss-on-modal-open';
+import { Dropdown } from './dropdown';
+
+describe('Dropdown', () => {
+  describe('Modal表示連動', () => {
+    it('Modalが開かれたイベントを受けるとメニューが閉じること', async () => {
+      render(
+        <Dropdown label="メニュー">
+          <Dropdown.Menu>
+            <Dropdown.Item>項目1</Dropdown.Item>
+            <Dropdown.Item>項目2</Dropdown.Item>
+          </Dropdown.Menu>
+        </Dropdown>,
+      );
+
+      // 開く（メニューの toggle ボタン）
+      fireEvent.click(screen.getByRole('button', { name: /メニュー/ }));
+      expect(screen.getByText('項目1')).toBeInTheDocument();
+
+      act(() => {
+        window.dispatchEvent(new CustomEvent(MODAL_OPEN_EVENT));
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByText('項目1')).not.toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/packages/component-ui/src/dropdown/dropdown.tsx
+++ b/packages/component-ui/src/dropdown/dropdown.tsx
@@ -5,6 +5,7 @@ import type { MutableRefObject, PropsWithChildren, ReactElement } from 'react';
 import { useCallback, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
+import { useDismissOnModalOpen } from '../hooks/use-dismiss-on-modal-open';
 import { useOutsideClick } from '../hooks/use-outside-click';
 import { Icon } from '../icon';
 import { DropdownContext } from './dropdown-context';
@@ -61,6 +62,11 @@ export function Dropdown({
 
   const targetRef = useRef<HTMLDivElement>(null);
   useOutsideClick(targetRef, () => setIsVisible(false));
+  useDismissOnModalOpen(() => {
+    if (isVisible) {
+      setIsVisible(false);
+    }
+  });
 
   const handleToggle = useCallback(() => {
     if (targetRef.current === null) {

--- a/packages/component-ui/src/hooks/use-dismiss-on-modal-open.test.ts
+++ b/packages/component-ui/src/hooks/use-dismiss-on-modal-open.test.ts
@@ -1,0 +1,48 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { MODAL_OPEN_EVENT, useDismissOnModalOpen } from './use-dismiss-on-modal-open';
+
+describe('useDismissOnModalOpen', () => {
+  it('zenkigen-modal-open イベントが発火するとdismissが呼ばれること', () => {
+    const dismiss = vi.fn();
+    renderHook(() => useDismissOnModalOpen(dismiss));
+
+    window.dispatchEvent(new CustomEvent(MODAL_OPEN_EVENT));
+
+    expect(dismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('アンマウント後にイベントが発火してもdismissが呼ばれないこと', () => {
+    const dismiss = vi.fn();
+    const { unmount } = renderHook(() => useDismissOnModalOpen(dismiss));
+
+    unmount();
+    window.dispatchEvent(new CustomEvent(MODAL_OPEN_EVENT));
+
+    expect(dismiss).not.toHaveBeenCalled();
+  });
+
+  it('dismissの参照が変わってもlistenerは再登録されず、最新のdismissが呼ばれること', () => {
+    const firstDismiss = vi.fn();
+    const secondDismiss = vi.fn();
+    const addSpy = vi.spyOn(window, 'addEventListener');
+    const initialAddCalls = addSpy.mock.calls.filter((call) => call[0] === MODAL_OPEN_EVENT).length;
+
+    const { rerender } = renderHook(({ dismiss }) => useDismissOnModalOpen(dismiss), {
+      initialProps: { dismiss: firstDismiss },
+    });
+
+    rerender({ dismiss: secondDismiss });
+
+    const afterAddCalls = addSpy.mock.calls.filter((call) => call[0] === MODAL_OPEN_EVENT).length;
+    expect(afterAddCalls - initialAddCalls).toBe(1);
+
+    window.dispatchEvent(new CustomEvent(MODAL_OPEN_EVENT));
+
+    expect(firstDismiss).not.toHaveBeenCalled();
+    expect(secondDismiss).toHaveBeenCalledTimes(1);
+
+    addSpy.mockRestore();
+  });
+});

--- a/packages/component-ui/src/hooks/use-dismiss-on-modal-open.ts
+++ b/packages/component-ui/src/hooks/use-dismiss-on-modal-open.ts
@@ -1,0 +1,29 @@
+import { useEffect, useRef } from 'react';
+
+export const MODAL_OPEN_EVENT = 'zenkigen-modal-open';
+
+/**
+ * Modal が開かれた瞬間に外側の floating UI を閉じるためのフック。
+ *
+ * Modal 側で `MODAL_OPEN_EVENT` が `window` に dispatch されたタイミングで、
+ * 引数の `dismiss` を呼び出す。
+ *
+ * 実装上の注意:
+ * - `dismissRef` で最新の `dismiss` を保持し、`useEffect` の依存配列は意図的に空にする
+ *   ことで、listener をマウント時に1回だけ登録する形にしている
+ * - `dismiss` が毎レンダーで新しい関数として渡されても、listener を貼り直さない
+ */
+export const useDismissOnModalOpen = (dismiss: () => void) => {
+  const dismissRef = useRef(dismiss);
+  dismissRef.current = dismiss;
+
+  useEffect(() => {
+    const handler = () => {
+      dismissRef.current();
+    };
+    window.addEventListener(MODAL_OPEN_EVENT, handler);
+
+    return () => window.removeEventListener(MODAL_OPEN_EVENT, handler);
+    // dismissRef は ref 経由で最新値を参照するため依存に含めない（意図的に空配列）
+  }, []);
+};

--- a/packages/component-ui/src/modal/modal.test.tsx
+++ b/packages/component-ui/src/modal/modal.test.tsx
@@ -1,0 +1,51 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { MODAL_OPEN_EVENT } from '../hooks/use-dismiss-on-modal-open';
+import { Modal } from './modal';
+
+describe('Modal', () => {
+  describe(`${MODAL_OPEN_EVENT} イベント発火`, () => {
+    it('isOpenがfalse→trueに切り替わると一度だけ発火すること', () => {
+      const handler = vi.fn();
+      window.addEventListener(MODAL_OPEN_EVENT, handler);
+
+      const { rerender } = render(<Modal isOpen={false}>content</Modal>);
+      expect(handler).not.toHaveBeenCalled();
+
+      rerender(<Modal isOpen>content</Modal>);
+      expect(handler).toHaveBeenCalledTimes(1);
+
+      window.removeEventListener(MODAL_OPEN_EVENT, handler);
+    });
+
+    it('isOpenを変えずに再レンダリングしても発火しないこと', () => {
+      const handler = vi.fn();
+      window.addEventListener(MODAL_OPEN_EVENT, handler);
+
+      const { rerender } = render(<Modal isOpen>content</Modal>);
+      expect(handler).toHaveBeenCalledTimes(1);
+
+      rerender(<Modal isOpen>other content</Modal>);
+      expect(handler).toHaveBeenCalledTimes(1);
+
+      window.removeEventListener(MODAL_OPEN_EVENT, handler);
+    });
+
+    it('true→false→trueの遷移で都度発火すること', () => {
+      const handler = vi.fn();
+      window.addEventListener(MODAL_OPEN_EVENT, handler);
+
+      const { rerender } = render(<Modal isOpen>content</Modal>);
+      expect(handler).toHaveBeenCalledTimes(1);
+
+      rerender(<Modal isOpen={false}>content</Modal>);
+      expect(handler).toHaveBeenCalledTimes(1);
+
+      rerender(<Modal isOpen>content</Modal>);
+      expect(handler).toHaveBeenCalledTimes(2);
+
+      window.removeEventListener(MODAL_OPEN_EVENT, handler);
+    });
+  });
+});

--- a/packages/component-ui/src/modal/modal.tsx
+++ b/packages/component-ui/src/modal/modal.tsx
@@ -2,6 +2,7 @@ import type { CSSProperties, MutableRefObject, PropsWithChildren } from 'react';
 import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 
+import { MODAL_OPEN_EVENT } from '../hooks/use-dismiss-on-modal-open';
 import { BodyScrollLock } from './body-scroll-lock';
 import { ModalBody } from './modal-body';
 import { ModalContext } from './modal-context';
@@ -37,6 +38,16 @@ export function Modal({
   useEffect(() => {
     setIsMounted(true);
   }, []);
+
+  // Modal が表示された瞬間に、外側で開いている floating UI（Select / Dropdown / Popover 等）を閉じるためのイベント発行。
+  // `isOpen` が false → true の遷移時だけでなく、初回マウント時に isOpen=true で渡された場合や、
+  // Modal を unmount → 再 mount した場合の表示時にも発火する。
+  // いずれも「Modal が新たに前面へ出てきた瞬間」なので、背景の floating UI を閉じる対象として正しい挙動。
+  useEffect(() => {
+    if (isOpen) {
+      window.dispatchEvent(new CustomEvent(MODAL_OPEN_EVENT));
+    }
+  }, [isOpen]);
 
   return isMounted && isOpen ? (
     <>

--- a/packages/component-ui/src/popover/popover-content.tsx
+++ b/packages/component-ui/src/popover/popover-content.tsx
@@ -2,6 +2,7 @@ import { FloatingPortal, useDismiss, useInteractions, useRole } from '@floating-
 import * as React from 'react';
 import { forwardRef, useCallback, useEffect, useRef } from 'react';
 
+import { useDismissOnModalOpen } from '../hooks/use-dismiss-on-modal-open';
 import { composeRefs, isElement } from '../utils';
 import { usePopoverContext } from './popover-context';
 
@@ -55,6 +56,13 @@ export const PopoverContent = forwardRef<HTMLDivElement, PopoverContentProps>(fu
   });
 
   const interactions = useInteractions([dismiss, useRole(floating.context, { role: 'dialog' })]);
+
+  // Modal が開かれた際に Popover を閉じる（利用側で reason='modal-open' を判定して挙動を変更可能）
+  useDismissOnModalOpen(() => {
+    if (isOpen && onClose != null) {
+      onClose({ reason: 'modal-open' });
+    }
+  });
 
   // Popover表示時にフォーカスを移動
   useEffect(() => {

--- a/packages/component-ui/src/popover/popover-context.ts
+++ b/packages/component-ui/src/popover/popover-context.ts
@@ -5,7 +5,7 @@ import { createContext, useContext } from 'react';
 /**
  * Popoverが閉じられる理由を定義する型
  */
-export type CloseReason = 'outside-click' | 'escape-key-down';
+export type CloseReason = 'outside-click' | 'escape-key-down' | 'modal-open';
 
 /**
  * Popoverのクローズイベントの型定義

--- a/packages/component-ui/src/popover/popover.stories.tsx
+++ b/packages/component-ui/src/popover/popover.stories.tsx
@@ -285,7 +285,16 @@ const PopoverInModalStory = () => {
       <Modal.Header>Modal 内の Popover</Modal.Header>
       <Modal.Body>
         <div className="flex min-h-[200px] flex-col items-center justify-center gap-4 pb-4">
-          <Popover isOpen={isPopoverOpen} placement="top" offset={8} onClose={() => setIsPopoverOpen(false)}>
+          <Popover
+            isOpen={isPopoverOpen}
+            placement="top"
+            offset={8}
+            onClose={(event) => {
+              // Modal 表示時の自動 close は無視して、VRT 用に Popover を開いたまま維持
+              if (event.reason === 'modal-open') return;
+              setIsPopoverOpen(false);
+            }}
+          >
             <Popover.Trigger>
               <Button variant="fill" onClick={() => setIsPopoverOpen((v) => !v)}>
                 {isPopoverOpen ? 'Popoverを非表示' : 'Popoverを表示'}

--- a/packages/component-ui/src/popover/popover.test.tsx
+++ b/packages/component-ui/src/popover/popover.test.tsx
@@ -1,9 +1,10 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
 import { Button } from '../button';
+import { MODAL_OPEN_EVENT } from '../hooks/use-dismiss-on-modal-open';
 import { Popover } from './popover';
 import type { PopoverCloseEvent } from './popover-context';
 
@@ -736,6 +737,52 @@ describe('Popover', () => {
           </Popover.Trigger>,
         );
       }).toThrow('Popover components must be used inside <Popover.Root>');
+    });
+  });
+
+  describe('Modal表示連動', () => {
+    it('Popover開いた状態でzenkigen-modal-openイベントを受けるとonCloseが呼ばれ、reasonが"modal-open"になること', async () => {
+      const onClose = vi.fn();
+      render(
+        <Popover isOpen onClose={onClose}>
+          <Popover.Trigger>
+            <Button>Open</Button>
+          </Popover.Trigger>
+          <Popover.Content>
+            <div data-testid="popover-content">Content</div>
+          </Popover.Content>
+        </Popover>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('popover-content')).toBeInTheDocument();
+      });
+
+      act(() => {
+        window.dispatchEvent(new CustomEvent(MODAL_OPEN_EVENT));
+      });
+
+      await waitFor(() => {
+        expect(onClose).toHaveBeenCalledWith({ reason: 'modal-open' });
+      });
+    });
+
+    it('Popoverが閉じた状態ではzenkigen-modal-openイベントを受けてもonCloseが呼ばれないこと', () => {
+      const onClose = vi.fn();
+      render(
+        <Popover isOpen={false} onClose={onClose}>
+          <Popover.Trigger>
+            <Button>Open</Button>
+          </Popover.Trigger>
+          <Popover.Content>
+            <div data-testid="popover-content">Content</div>
+          </Popover.Content>
+        </Popover>,
+      );
+
+      window.dispatchEvent(new CustomEvent(MODAL_OPEN_EVENT));
+
+      expect(onClose).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/component-ui/src/select-sort/select-sort.test.tsx
+++ b/packages/component-ui/src/select-sort/select-sort.test.tsx
@@ -1,0 +1,25 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { MODAL_OPEN_EVENT } from '../hooks/use-dismiss-on-modal-open';
+import { SelectSort } from './select-sort';
+
+describe('SelectSort', () => {
+  describe('Modal表示連動', () => {
+    it('Modalが開かれたイベントを受けるとオプションリストが閉じること', async () => {
+      render(<SelectSort label="氏名" sortOrder={null} />);
+
+      // 開く
+      fireEvent.click(screen.getByRole('button'));
+      expect(screen.getByRole('list')).toBeInTheDocument();
+
+      act(() => {
+        window.dispatchEvent(new CustomEvent(MODAL_OPEN_EVENT));
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByRole('list')).not.toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/packages/component-ui/src/select-sort/select-sort.tsx
+++ b/packages/component-ui/src/select-sort/select-sort.tsx
@@ -3,6 +3,7 @@ import clsx from 'clsx';
 import type { CSSProperties } from 'react';
 import { useCallback, useRef, useState } from 'react';
 
+import { useDismissOnModalOpen } from '../hooks/use-dismiss-on-modal-open';
 import { useOutsideClick } from '../hooks/use-outside-click';
 import { Icon } from '../icon';
 import { SelectList } from './select-list';
@@ -43,6 +44,11 @@ export function SelectSort({
   const [isOptionListOpen, setIsOptionListOpen] = useState(false);
   const targetRef = useRef<HTMLDivElement>(null);
   useOutsideClick(targetRef, () => setIsOptionListOpen(false));
+  useDismissOnModalOpen(() => {
+    if (isOptionListOpen) {
+      setIsOptionListOpen(false);
+    }
+  });
 
   const handleClickToggle = () => setIsOptionListOpen((prev) => !prev);
   const handleClickItem = useCallback(

--- a/packages/component-ui/src/select/select.stories.tsx
+++ b/packages/component-ui/src/select/select.stories.tsx
@@ -1,8 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { IconName } from '@zenkigen-inc/component-icons';
 import { iconElements } from '@zenkigen-inc/component-icons';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
+import { Button } from '../button';
+import { Modal } from '../modal';
 import { Select } from './select';
 import type { SelectOption } from './type';
 
@@ -820,3 +822,103 @@ export function MatchListToTrigger() {
     </div>
   );
 }
+
+/**
+ * 裏側の非同期処理でエラーが発生し、Select 操作中に Modal が自動表示されるケースを想定した Story。
+ *
+ * Story が描画されると以下が自動的に進む:
+ * 1. 1秒後に Select の List が自動的に開く
+ * 2. 3秒後（Select 表示の2秒後）に Modal が自動的に表示される
+ * 3. Modal の表示と同時に Select の List が自動で閉じる
+ *
+ * 自動で閉じる仕組み:
+ * - Modal は `isOpen` が false → true に切り替わる瞬間に `window` へ
+ *   `zenkigen-modal-open` カスタムイベントを dispatch する
+ * - Select 内部の `useDismissOnModalOpen` フックがそのイベントを listen し、
+ *   受信時に自身の List を閉じる setter を呼び出す
+ * - 同じ仕組みで Dropdown / SelectSort / Popover / DatePicker（Popover 経由）も
+ *   Modal 表示時に自動で閉じる
+ *
+ * Modal を閉じてもう一度確認したい場合は、Storybook 側でこの Story を再描画する。
+ */
+function DismissOnModalOpenContent() {
+  const [selectedOption, setSelectedOption] = useState<SelectOption | null>(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    // 1秒後に Select を自動的に開く
+    const openSelectTimer = window.setTimeout(() => {
+      const selectButton = containerRef.current?.querySelector<HTMLButtonElement>('button[type="button"]');
+      selectButton?.click();
+    }, 1000);
+
+    // 3秒後（Select 表示の2秒後）に Modal を自動的に開く
+    const openModalTimer = window.setTimeout(() => {
+      setIsModalOpen(true);
+    }, 3000);
+
+    return () => {
+      window.clearTimeout(openSelectTimer);
+      window.clearTimeout(openModalTimer);
+    };
+  }, []);
+
+  return (
+    <div ref={containerRef} className="flex flex-col gap-4">
+      <div className="flex flex-col gap-2 rounded border border-uiBorder01 bg-uiBackgroundBlue p-4">
+        <p className="typography-label14bold text-text01">Modal 表示時に Select の List が自動で閉じることを確認する</p>
+        <p className="typography-body14regular text-text01">
+          1秒後に Select が自動で開き、さらに 2秒後に Modal が表示される。Modal の表示と同時に Select の List
+          が閉じれば成功。
+        </p>
+      </div>
+      <Select
+        size="medium"
+        variant="outline"
+        placeholder="選択"
+        selectedOption={selectedOption}
+        onChange={(option) => setSelectedOption(option)}
+        width={240}
+      >
+        {optionsList.map((option) => (
+          <Select.Option key={option.id} option={option} />
+        ))}
+      </Select>
+      <Modal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} width={480}>
+        <Modal.Header>自動表示された Modal（デモ）</Modal.Header>
+        <Modal.Body>
+          <div className="px-6 pb-4">
+            <p className="typography-body14regular text-text01">
+              Modal が表示されました。背景の Select は自動的に閉じています。
+            </p>
+          </div>
+        </Modal.Body>
+        <Modal.Footer>
+          <div className="flex w-full items-center justify-end">
+            <Button variant="outline" size="medium" onClick={() => setIsModalOpen(false)}>
+              閉じる
+            </Button>
+          </div>
+        </Modal.Footer>
+      </Modal>
+    </div>
+  );
+}
+
+export const DismissOnModalOpen: Story = {
+  render: () => <DismissOnModalOpenContent />,
+  parameters: {
+    docs: {
+      description: {
+        story: [
+          'Modal 表示時に Select の List が自動で閉じることを確認する Story。',
+          '',
+          '1秒後に Select が自動で開き、さらに 2秒後に Modal が表示される。Modal の表示と同時に Select の List が閉じれば成功。',
+          '',
+          '**仕組み**: Modal は `isOpen` が `true` に切り替わる瞬間に `window` へ `zenkigen-modal-open` カスタムイベントを dispatch する。Select 内部の `useDismissOnModalOpen` フックがそれを listen して List を閉じる。同じ仕組みが Dropdown / SelectSort / Popover / DatePicker（Popover 経由）にも横展開されている。',
+        ].join('\n'),
+      },
+    },
+  },
+};

--- a/packages/component-ui/src/select/select.stories.tsx
+++ b/packages/component-ui/src/select/select.stories.tsx
@@ -909,6 +909,7 @@ function DismissOnModalOpenContent() {
 export const DismissOnModalOpen: Story = {
   render: () => <DismissOnModalOpenContent />,
   parameters: {
+    chromatic: { disable: true },
     docs: {
       description: {
         story: [

--- a/packages/component-ui/src/select/select.test.tsx
+++ b/packages/component-ui/src/select/select.test.tsx
@@ -1,7 +1,8 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React, { useState } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
+import { MODAL_OPEN_EVENT } from '../hooks/use-dismiss-on-modal-open';
 import { Select } from './select';
 import type { SelectOption } from './type';
 
@@ -154,6 +155,24 @@ describe('Select', () => {
       expect(screen.getByRole('list')).toBeInTheDocument();
 
       fireEvent.click(screen.getByTestId('outside'));
+
+      await waitFor(() => {
+        expect(screen.queryByRole('list')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Modal表示連動', () => {
+    it('Modalが開かれたイベントを受けるとオプションリストが閉じること', async () => {
+      render(<SelectTestComponent placeholder="選択" />);
+
+      const selectButton = screen.getByRole('button');
+      fireEvent.click(selectButton);
+      expect(screen.getByRole('list')).toBeInTheDocument();
+
+      act(() => {
+        window.dispatchEvent(new CustomEvent(MODAL_OPEN_EVENT));
+      });
 
       await waitFor(() => {
         expect(screen.queryByRole('list')).not.toBeInTheDocument();

--- a/packages/component-ui/src/select/select.tsx
+++ b/packages/component-ui/src/select/select.tsx
@@ -5,6 +5,7 @@ import clsx from 'clsx';
 import type { CSSProperties, PropsWithChildren, RefObject } from 'react';
 import { useRef, useState } from 'react';
 
+import { useDismissOnModalOpen } from '../hooks/use-dismiss-on-modal-open';
 import { useOutsideClick } from '../hooks/use-outside-click';
 import { Icon } from '../icon';
 import { SelectContext } from './select-context';
@@ -63,6 +64,11 @@ export function Select({
   const [isOptionListOpen, setIsOptionListOpen] = useState(false);
   const targetRef = useRef<HTMLDivElement>(null);
   useOutsideClick(targetRef, () => setIsOptionListOpen(false));
+  useDismissOnModalOpen(() => {
+    if (isOptionListOpen) {
+      setIsOptionListOpen(false);
+    }
+  });
 
   // Floating UI の設定
   const { refs, floatingStyles } = useFloating({


### PR DESCRIPTION
> [!NOTE]
> - Selectなどでリストが 開いている場面で、モーダルが自動的に開くと Select が最前面に表示されてしまい不具合の修正
> - 検証用のStoryを追加している https://639bcc36e4bdc7deb6496ad2-zbjdcstzuo.chromatic.com/?path=/story/components-select--dismiss-on-modal-open
> - 利用者がわでの対応は不要

## 概要

Modal が表示された瞬間に、外側で開いている floating UI（Select / Dropdown / SelectSort / Popover / DatePicker）を自動的に閉じる仕組みを追加した。Select 操作中に裏側の処理（エラー検知など）で Modal が自動表示されると、Select の List が Modal の上に被さって描画されてしまう問題への対策。

## 主な機能

- **共通フック `useDismissOnModalOpen`**: Modal が `window` に発行するカスタムイベントを listen して、自身を閉じる処理を実行
- **Modal**: `isOpen` が `true` になる瞬間に `zenkigen-modal-open` カスタムイベントを `window` へ dispatch
- **横展開**: Select / Dropdown / SelectSort / Popover にフックを組み込み。DatePicker は内部で Popover を controlled で使う構造のため、Popover 経由で間接的に閉じる

## 設計判断

z-index 階層の修正や `FloatingPortal` の portal 先切り替えで重なり順を制御する方針も検討したが、`ModalContext` / `FloatingPortal` の構造改修が必要で「Modal 内 Select」「Modal 内 Popover 内 Select」を壊さない実装が複雑化するため不採用。

代わりに「Modal が表示された瞬間に背景の floating UI を一斉に閉じる」UX 寄りのアプローチを採用した。操作対象が Modal に切り替わる以上、背景の floating UI を閉じるのは UX 的にも自然で、実装も局所的に収まる。

## 変更内容

### 変更ファイル

| ファイル | 内容 |
|---|---|
| `packages/component-ui/src/hooks/use-dismiss-on-modal-open.ts` | 共通フック新規作成 |
| `packages/component-ui/src/hooks/use-dismiss-on-modal-open.test.ts` | フックのテスト新規作成 |
| `packages/component-ui/src/modal/modal.tsx` | `isOpen` 遷移時にカスタムイベントを dispatch |
| `packages/component-ui/src/modal/modal.test.tsx` | Modal のイベント発火テスト新規作成 |
| `packages/component-ui/src/select/select.tsx` | フックを組み込み |
| `packages/component-ui/src/select/select.test.tsx` | Modal 表示連動テスト追加 |
| `packages/component-ui/src/select/select.stories.tsx` | 動作確認用 Story `DismissOnModalOpen` を追加 |
| `packages/component-ui/src/dropdown/dropdown.tsx` | フックを組み込み |
| `packages/component-ui/src/dropdown/dropdown.test.tsx` | Modal 表示連動テスト新規作成 |
| `packages/component-ui/src/select-sort/select-sort.tsx` | フックを組み込み |
| `packages/component-ui/src/select-sort/select-sort.test.tsx` | Modal 表示連動テスト新規作成 |
| `packages/component-ui/src/popover/popover-context.ts` | `CloseReason` 型に `'modal-open'` を追加 |
| `packages/component-ui/src/popover/popover-content.tsx` | フック経由で `onClose({ reason: 'modal-open' })` を発火 |
| `packages/component-ui/src/popover/popover.test.tsx` | Modal 表示連動テスト追加 |
| `packages/component-ui/src/popover/popover.stories.tsx` | `PopoverInModalStory` の `onClose` で `modal-open` を無視する追従修正 |
| `packages/component-ui/src/date-picker/date-picker.test.tsx` | Modal 表示連動テスト追加（Popover 経由の間接対応の検証） |

## 影響範囲

### 破壊的変更: `CloseReason` 型の union 拡張

`popover-context.ts` の `CloseReason` 型に `'modal-open'` を追加した:

```diff
- export type CloseReason = 'outside-click' | 'escape-key-down';
+ export type CloseReason = 'outside-click' | 'escape-key-down' | 'modal-open';
```

利用側で `event.reason` を `switch` / `if-else` で網羅判定している場合に挙動変化が起こり得るが、利用されている場場面は稀と想定している。

| パターン | 検出 | 修正コスト | 発生確率 |
|---|---|---|---|
| `switch` で exhaustive check | TS ビルドエラー | 低 | 中 |
| `if-else` で網羅判定し else に fallback | **ランタイムまで気づかない** | 低 | 中〜高 |
| 単純に `setIsOpen(false)` | 挙動変化のみ | 1行追加 | 低 |

「Modal 表示時も Popover を閉じたくない」要件がある場合は、利用側で次のように分岐すれば従来挙動を維持できる:

```tsx
const handleClose = (event: PopoverCloseEvent) => {
  if (event.reason === 'modal-open') return;
  setIsOpen(false);
};
```

### 影響を受けるコンポーネント

- `Select` / `Dropdown` / `SelectSort` / `Popover` / `DatePicker`

## テスト観点

- 共通フック単体: イベント発火で `dismiss` が呼ばれること / アンマウント後に呼ばれないこと / `dismiss` 参照が変わっても listener 再登録されないこと
- Modal: `isOpen` の `false → true` 遷移で `zenkigen-modal-open` が1回発火、再レンダーで発火しない、`true → false → true` で都度発火
- 各コンポーネント: 開いた状態で `zenkigen-modal-open` を受信すると閉じる（Popover は `onClose({ reason: 'modal-open' })` 発火、閉じた状態では `onClose` を呼ばない）
- DatePicker: Popover 経由で間接的に Calendar が閉じる

## テスト手順

- [ ] Storybook の `Components/Select > Dismiss On Modal Open` を開き、1秒後に Select の List が自動で開き、3秒後に Modal が表示されると同時に List が閉じることを確認
- [ ] `Components/Popover > Open In Modal` で Modal 内 Popover が初期 open のまま正しく表示されること（既存 Story の regression がないこと）
- [ ] Modal 内 Select の通常開閉に regression がないこと（例: `Modal` の Story の TaskForm 系）

## 実行したコマンド

- `yarn build:all` — OK
- `yarn lint` — 今回触ったファイルは OK（残った prettier 警告は既存の `tmp/` 配下と既存 lint エラー由来）
- `yarn type-check` — OK
- `yarn test:ci` — 22 files / 439 passed, 2 skipped