### PR TITLE
310｜ci: add dependency audit workflow and npm minimal-age gate

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -1,0 +1,57 @@
+name: Audit
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+    paths:
+      - 'package.json'
+      - 'packages/**/package.json'
+      - 'yarn.lock'
+      - '.yarnrc.yml'
+      - '.github/workflows/audit.yaml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'package.json'
+      - 'packages/**/package.json'
+      - 'yarn.lock'
+      - '.yarnrc.yml'
+      - '.github/workflows/audit.yaml'
+  schedule:
+    # 毎日 09:00 JST (00:00 UTC) に実行: 上流の新規脆弱性を検知する
+    - cron: '0 0 * * *'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@main
+
+      - name: Read Node version from .node-version
+        run: echo "node_version=$(cat .node-version)" >> $GITHUB_OUTPUT
+        id: node-version
+
+      - name: Use Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ steps.node-version.outputs.node_version }}
+
+      - name: Yarn install
+        uses: ./.github/actions/yarn-install
+
+      # 初回は報告のみ（continue-on-error）。Linux CI 上での実際の検出内容を確認し、
+      # dev / ビルドツール由来の確定誤検知を整理したうえで continue-on-error を外し、
+      # high 以上でジョブを失敗させるブロッキング運用へ切り替える。
+      - name: Audit production dependencies (high and above)
+        continue-on-error: true
+        run: yarn npm audit --all --recursive --environment production --severity high

--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@v6
 
       - name: Read Node version from .node-version
         run: echo "node_version=$(cat .node-version)" >> $GITHUB_OUTPUT

--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -49,9 +49,6 @@ jobs:
       - name: Yarn install
         uses: ./.github/actions/yarn-install
 
-      # 初回は報告のみ（continue-on-error）。Linux CI 上での実際の検出内容を確認し、
-      # dev / ビルドツール由来の確定誤検知を整理したうえで continue-on-error を外し、
-      # high 以上でジョブを失敗させるブロッキング運用へ切り替える。
+      # production 依存に high 以上の脆弱性が見つかった場合はジョブを失敗させる。
       - name: Audit production dependencies (high and above)
-        continue-on-error: true
         run: yarn npm audit --all --recursive --environment production --severity high

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,5 +1,12 @@
 nodeLinker: node-modules
 
+# リリースから 3 日未満のパッケージバージョンは install をブロックする（0-day / 改ざん版対策）。
+# pnpm の minimumReleaseAge=4320(分) 相当。Yarn 4.10+ のネイティブ機能。
+npmMinimalAgeGate: '3d'
+
+# package.json に保存するバージョンを exact 固定する（save-exact 相当）。
+defaultSemverRangePrefix: ''
+
 npmScopes:
   zenkigen-inc:
     npmAuthToken: '${NODE_AUTH_TOKEN-}'

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -7,6 +7,11 @@ npmMinimalAgeGate: '3d'
 # package.json に保存するバージョンを exact 固定する（save-exact 相当）。
 defaultSemverRangePrefix: ''
 
+# 依存パッケージの install スクリプト（preinstall / install / postinstall）を既定で実行しない。
+# install 時の任意コード実行（認証情報・publish トークンの窃取／自己増殖）を遮断するためのセキュリティ設定。
+# ビルドが必要なパッケージのみ package.json の dependenciesMeta.<pkg>.built で allowlist する。
+enableScripts: false
+
 npmScopes:
   zenkigen-inc:
     npmAuthToken: '${NODE_AUTH_TOKEN-}'

--- a/package.json
+++ b/package.json
@@ -5,6 +5,11 @@
   "workspaces": [
     "packages/*"
   ],
+  "dependenciesMeta": {
+    "esbuild": {
+      "built": true
+    }
+  },
   "scripts": {
     "lint": "eslint './packages/**/*.ts{,x}' && prettier --check .",
     "lint:fix": "eslint './packages/**/*.ts{,x}' --fix && prettier --write .",

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "extends": ["config:base"],
   "timezone": "Asia/Tokyo",
   "schedule": "on saturday",
+  "minimumReleaseAge": "3 days",
   "labels": ["renovate"],
   "reviewers": ["Syunki0403"],
   "lockFileMaintenance": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2016,22 +2016,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@isaacs/balanced-match@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "@isaacs/balanced-match@npm:4.0.1"
-  checksum: 10c0/7da011805b259ec5c955f01cee903da72ad97c5e6f01ca96197267d3f33103d5b2f8a1af192140f3aa64526c593c8d098ae366c2b11f7f17645d12387c2fd420
-  languageName: node
-  linkType: hard
-
-"@isaacs/brace-expansion@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "@isaacs/brace-expansion@npm:5.0.0"
-  dependencies:
-    "@isaacs/balanced-match": "npm:^4.0.1"
-  checksum: 10c0/b4d4812f4be53afc2c5b6c545001ff7a4659af68d4484804e9d514e183d20269bb81def8682c01a22b17c4d6aed14292c8494f7d2ac664e547101c1a905aa977
-  languageName: node
-  linkType: hard
-
 "@isaacs/cliui@npm:^8.0.2":
   version: 8.0.2
   resolution: "@isaacs/cliui@npm:8.0.2"
@@ -3896,6 +3880,15 @@ __metadata:
   dependencies:
     balanced-match: "npm:^1.0.0"
   checksum: 10c0/6d117a4c793488af86b83172deb6af143e94c17bc53b0b3cec259733923b4ca84679d506ac261f4ba3c7ed37c46018e2ff442f9ce453af8643ecd64f4a54e6cf
+  languageName: node
+  linkType: hard
+
+"brace-expansion@npm:^2.0.2":
+  version: 2.1.0
+  resolution: "brace-expansion@npm:2.1.0"
+  dependencies:
+    balanced-match: "npm:^1.0.0"
+  checksum: 10c0/439cedf3e23d7993b37919f1d6fdc653ec21a42437ec3e7460bea9ca8b17edf7a24a633273c31d61aa4335877cf29a443f1871814131c87997a1e6223e1f1502
   languageName: node
   linkType: hard
 
@@ -7055,16 +7048,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^10.1.1":
-  version: 10.1.1
-  resolution: "minimatch@npm:10.1.1"
-  dependencies:
-    "@isaacs/brace-expansion": "npm:^5.0.0"
-  checksum: 10c0/c85d44821c71973d636091fddbfbffe62370f5ee3caf0241c5b60c18cd289e916200acb2361b7e987558cd06896d153e25d505db9fc1e43e6b4b6752e2702902
-  languageName: node
-  linkType: hard
-
-"minimatch@npm:^10.2.2":
+"minimatch@npm:^10.1.1, minimatch@npm:^10.2.2":
   version: 10.2.5
   resolution: "minimatch@npm:10.2.5"
   dependencies:
@@ -7073,16 +7057,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^3.0.4, minimatch@npm:^3.1.2":
-  version: 3.1.2
-  resolution: "minimatch@npm:3.1.2"
-  dependencies:
-    brace-expansion: "npm:^1.1.7"
-  checksum: 10c0/0262810a8fc2e72cca45d6fd86bd349eee435eb95ac6aa45c9ea2180e7ee875ef44c32b55b5973ceabe95ea12682f6e3725cbb63d7a2d1da3ae1163c8b210311
-  languageName: node
-  linkType: hard
-
-"minimatch@npm:^3.1.5":
+"minimatch@npm:^3.0.4, minimatch@npm:^3.1.2, minimatch@npm:^3.1.5":
   version: 3.1.5
   resolution: "minimatch@npm:3.1.5"
   dependencies:
@@ -7092,20 +7067,20 @@ __metadata:
   linkType: hard
 
 "minimatch@npm:^5.0.1":
-  version: 5.1.6
-  resolution: "minimatch@npm:5.1.6"
+  version: 5.1.9
+  resolution: "minimatch@npm:5.1.9"
   dependencies:
     brace-expansion: "npm:^2.0.1"
-  checksum: 10c0/3defdfd230914f22a8da203747c42ee3c405c39d4d37ffda284dac5e45b7e1f6c49aa8be606509002898e73091ff2a3bbfc59c2c6c71d4660609f63aa92f98e3
+  checksum: 10c0/4202718683815a7288b13e470160a4f9560cf392adef4f453927505817e01ef6b3476ecde13cfcaed17e7326dd3b69ad44eb2daeb19a217c5500f9277893f1d6
   languageName: node
   linkType: hard
 
 "minimatch@npm:^9.0.4, minimatch@npm:^9.0.5":
-  version: 9.0.5
-  resolution: "minimatch@npm:9.0.5"
+  version: 9.0.9
+  resolution: "minimatch@npm:9.0.9"
   dependencies:
-    brace-expansion: "npm:^2.0.1"
-  checksum: 10c0/de96cf5e35bdf0eab3e2c853522f98ffbe9a36c37797778d2665231ec1f20a9447a7e567cb640901f89e4daaa95ae5d70c65a9e8aa2bb0019b6facbc3c0575ed
+    brace-expansion: "npm:^2.0.2"
+  checksum: 10c0/0b6a58530dbb00361745aa6c8cffaba4c90f551afe7c734830bd95fd88ebf469dd7355a027824ea1d09e37181cfeb0a797fb17df60c15ac174303ac110eb7e86
   languageName: node
   linkType: hard
 
@@ -7709,16 +7684,16 @@ __metadata:
   linkType: hard
 
 "picomatch@npm:^2.0.4, picomatch@npm:^2.2.1, picomatch@npm:^2.3.1":
-  version: 2.3.1
-  resolution: "picomatch@npm:2.3.1"
-  checksum: 10c0/26c02b8d06f03206fc2ab8d16f19960f2ff9e81a658f831ecb656d8f17d9edc799e8364b1f4a7873e89d9702dff96204be0fa26fe4181f6843f040f819dac4be
+  version: 2.3.2
+  resolution: "picomatch@npm:2.3.2"
+  checksum: 10c0/a554d1709e59be97d1acb9eaedbbc700a5c03dbd4579807baed95100b00420bc729335440ef15004ae2378984e2487a7c1cebd743cfdb72b6fa9ab69223c0d61
   languageName: node
   linkType: hard
 
 "picomatch@npm:^4.0.2, picomatch@npm:^4.0.3":
-  version: 4.0.3
-  resolution: "picomatch@npm:4.0.3"
-  checksum: 10c0/9582c951e95eebee5434f59e426cddd228a7b97a0161a375aed4be244bd3fe8e3a31b846808ea14ef2c8a2527a6eeab7b3946a67d5979e81694654f939473ae2
+  version: 4.0.4
+  resolution: "picomatch@npm:4.0.4"
+  checksum: 10c0/e2c6023372cc7b5764719a5ffb9da0f8e781212fa7ca4bd0562db929df8e117460f00dff3cb7509dacfc06b86de924b247f504d0ce1806a37fac4633081466b0
   languageName: node
   linkType: hard
 
@@ -9111,15 +9086,15 @@ __metadata:
   linkType: hard
 
 "tar@npm:^7.5.4":
-  version: 7.5.7
-  resolution: "tar@npm:7.5.7"
+  version: 7.5.15
+  resolution: "tar@npm:7.5.15"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/51f261afc437e1112c3e7919478d6176ea83f7f7727864d8c2cce10f0b03a631d1911644a567348c3063c45abdae39718ba97abb073d22aa3538b9a53ae1e31c
+  checksum: 10c0/8f039edb1d12fdd7df6c6f9877d125afe9f3da3f5f9317df326fdd090d48793d6998cede1506a1471f3e3a250db270a89dace28005eb5e99c5a9132d704ac956
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10155,5 +10155,8 @@ __metadata:
     typescript: "npm:5.9.3"
     vite: "npm:7.3.1"
     vitest: "npm:3.2.4"
+  dependenciesMeta:
+    esbuild:
+      built: true
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## 概要

npm 依存パッケージの脆弱性対策。以下の 4 点を導入する。

- **age gate + exact 固定**（`.yarnrc.yml`）— リリース 3 日未満のバージョン install をブロック
- **Audit workflow 新設** — PR / push(main) / 日次で `yarn npm audit` を実行
- **既存 high 脆弱性の解消** — そのうえで audit をブロッキング運用に
- **install スクリプトの既定無効化** — install 時の任意コード実行を遮断

## 背景

- 一般的な pnpm / `.npmrc` ベースの設定は、本リポジトリには**そのまま適用できない**。
  - 本リポジトリは **Yarn 4.13.0 (Berry)**。
  - Yarn Berry は `.npmrc` を registry / auth 以外読まない → 設定先は `.yarnrc.yml`。
- そこで各設定を Yarn Berry 相当へ置き換えた（下表）。

| 目的 | pnpm / .npmrc | 本 PR (Yarn Berry / .yarnrc.yml) |
|---|---|---|
| リリース 3 日未満を install ブロック（0-day / 改ざん版対策） | `minimum-release-age=4320`（単位: 分） | `npmMinimalAgeGate: "3d"`（Yarn 4.10+ のネイティブ。期間文字列） |
| 保存バージョンを exact 固定 | `save-exact=true` | `defaultSemverRangePrefix: ""` |
| install スクリプトを既定で無効化（install 時の任意コード実行を遮断） | （pnpm 10+ は `onlyBuiltDependencies` allowlist が既定 deny） | `enableScripts: false` ＋ `dependenciesMeta.<pkg>.built` allowlist |
| production 依存を high 以上で監査 | `pnpm audit --audit-level=high --prod` | `yarn npm audit --all --recursive --environment production --severity high` |

## 変更内容

| ファイル | 種別 | 内容 |
|---|---|---|
| `.yarnrc.yml` | 修正 | `npmMinimalAgeGate: '3d'` / `defaultSemverRangePrefix: ''` / `enableScripts: false` を追加 |
| `package.json` | 修正 | `dependenciesMeta.esbuild.built: true` を追加（`enableScripts: false` 下で唯一ビルドが必要な esbuild のみ allowlist） |
| `.github/workflows/audit.yaml` | 新規 | PR / push(main) / 日次 cron(00:00 UTC = 09:00 JST) で production 依存を high 以上で監査し、検出時はジョブを失敗させる |
| `yarn.lock` | 修正 | `minimatch` / `picomatch` / `tar` / `@isaacs/brace-expansion` を修正版へ更新（既存 high 脆弱性を解消） |
| `renovate.json` | 修正 | `minimumReleaseAge: "3 days"` を追加（age gate と整合し、3 日未満の更新 PR を作らない） |

## 設計判断

- **install スクリプトの遮断（`enableScripts: false`）**
  - 依存の preinstall / install / postinstall を既定で実行させない。
  - 目的: install 時の任意コード実行（認証情報・publish トークンの窃取／自己増殖）の防止。
  - `.yarnrc.yml` に commit するため**手元・CI 両方**に効く。
  - 調査結果: 実際にビルドスクリプトを実行する依存は **esbuild のみ**（他はテストフィクスチャ等）。→ esbuild だけ `dependenciesMeta` で allowlist。
  - 確認済: `yarn install` / `build:all` / `test:ci`（484 passed）が通る。
  - 運用: 今後ビルドが必要な依存を追加すると install 時に YN0004 警告が出る → その都度 allowlist に追記。
- **脆弱性は dev / ビルドツール系の transitive のみ**だった。
  - 該当: `minimatch` / `picomatch` / `tar` / `@isaacs/brace-expansion`（経由: `filelist`(jake) / `glob` / `micromatch` / `tinyglobby` / `node-gyp`）。
  - 出荷パッケージの production 依存（`@floating-ui/react` / `clsx` / `react-day-picker`）には high なし。
  - `yarn up -R` で修正版へ → `No audit suggestions` → `continue-on-error` なしで**最初からブロッキング**導入。
- **`yarn npm audit` は lockfile を監査する**（OS フィルタ後の install ツリーではない）。
  - → 検出結果は macOS / Linux で同一（Linux CI でも `node-gyp` / `tar` 等は検出される）。

## スコープ外 / 非ゴール

- proxy レジストリ（Takumi Guard）経由スキャンの CI 適用 → 後続 PR
- `engine-strict` 相当 → Yarn Berry に強制機構が無いため見送り

## テスト手順

- [ ] この PR の Audit ジョブ（Linux）が緑（high 0 件）
- [ ] 既存 CI（type-check / lint / test / Chromatic）が緑

## 実行したコマンド

- `yarn npm audit --all --recursive --environment production --severity high` → **No audit suggestions（exit 0）**
- `yarn install`（`enableScripts: false` + esbuild allowlist）→ esbuild のみビルド・他に build 要求なし
- `yarn build:all` → OK
- `yarn type-check` → OK
- `yarn test:ci` → 484 passed, 2 skipped