### PR TITLE
310｜ci: route CI installs through Takumi Guard (anonymous)

### DIFF
--- a/.github/actions/yarn-install/action.yaml
+++ b/.github/actions/yarn-install/action.yaml
@@ -15,6 +15,12 @@ runs:
         key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
         restore-keys: ${{ runner.os }}-yarn-
 
+    # install を Takumi Guard（npm.flatt.tech）経由にし、既知の悪性パッケージをブロックする。
+    # 匿名モード（bot-id なし / Tier A ブロッキングのみ）のため id-token 権限は不要で、fork PR でも動作する。
+    # cache にある依存は再 fetch されないため、screen 対象は cache-miss する新規/更新依存（方針A）。
+    - name: Setup Takumi Guard (anonymous, blocking only)
+      uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
+
     - name: Install dependencies
       shell: bash
       run: yarn install

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -12,6 +12,10 @@ defaultSemverRangePrefix: ''
 # ビルドが必要なパッケージのみ package.json の dependenciesMeta.<pkg>.built で allowlist する。
 enableScripts: false
 
+# CI で install を Takumi Guard（proxy レジストリ）経由にした際、脆弱性 audit の問い合わせ先は
+# npmjs に固定する（proxy 経由だと advisory を取得できず偽 green になる恐れがあるため）。
+npmAuditRegistry: 'https://registry.npmjs.org'
+
 npmScopes:
   zenkigen-inc:
     npmAuthToken: '${NODE_AUTH_TOKEN-}'


### PR DESCRIPTION
> [!NOTE]
> この PR は #579 にスタックしています（base = `feat/dependency-security-audit`）。先に #579 をマージしてください。

## 概要

- CI のパッケージ install を **Takumi Guard（`npm.flatt.tech`）経由**にし、既知の悪性パッケージをブロックする。
- #579 で見送った「レジストリ経由スキャン」を、committed なグローバル設定ではなく **CI 内のみ**で適用する。

## 方針

- **匿名モード（bot-id なし / Tier A ブロッキングのみ）**
  - `id-token: write`（OIDC）が不要 → 外部コントリビュータの **fork PR でも動作**する。
  - 追跡ログ（bot-id）は後から追加可能（その場合 OIDC 必要・fork PR は対象外）。
- **screen 範囲 = cache-miss する新規/更新依存（方針A）**
  - CI は `actions/cache` を復元するため、キャッシュ済みの依存は再 fetch されず Takumi を通らない。
  - 新規/更新依存（PR・renovate での混入経路）は cache-miss → fetch → screen される。
  - `--check-cache` での全件再取得は CI 速度・proxy 依存の観点から不採用。
- **`publish.yaml` は対象外（意図的なスコープ外）**
  - **破壊リスク**: Takumi は Yarn Berry では `YARN_NPM_REGISTRY_SERVER` / `YARN_NPM_AUTH_TOKEN` を `$GITHUB_ENV` 経由でエクスポートし、同一 job の後続 step 全体に永続させる。本リポジトリの `.yarnrc.yml` は `npmScopes.zenkigen-inc` に registry を指定せずグローバル設定に依存するため、Takumi の "scoped registry は上書きしない" 保護が効かず、`yarn publish:all` の publish 先まで proxy に向き公開が壊れる恐れがある。
  - **追加価値が乏しい**: publish は tag が指す commit の `yarn.lock` を使い、Yarn が install 時に checksum(integrity) を検証するため、入る依存は ci/chromatic/audit が検証したものと bit 単位で同一。さらに Takumi は cache-miss する新規/更新依存のみを screen するため、同一 lock の publish では判定対象が実質ない。
  - publish step に `YARN_NPM_REGISTRY_SERVER` を npmjs 固定する防御を入れれば適用は技術的に可能だが、実 publish（tag push）でしか検証できず、得られる追加防御もほぼないため本 PR では見送る。

## 変更内容

| ファイル | 種別 | 内容 |
|---|---|---|
| `.github/actions/yarn-install/action.yaml` | 修正 | `flatt-security/setup-takumi-guard-npm`（匿名・フル SHA ピン `9a5d797…` = v1.1.1）を install 直前に追加。これを使う ci.yaml(3 job) / chromatic.yaml / audit.yaml が Takumi 経由になる |
| `.yarnrc.yml` | 修正 | `npmAuditRegistry: 'https://registry.npmjs.org'` を追加。install registry を proxy に上書きしても audit の advisory 問い合わせは npmjs に固定（偽 green 防止） |

## 設計判断 / 確認した点

- 匿名モードは `id-token: write` 不要（action.yml で確認）→ workflow の permissions 変更なし。
- registry を flatt.tech に上書きしても `npmAuditRegistry` により audit は npmjs に向くことをローカル確認。
  - `No audit suggestions` / exit 0、`yarn config get npmAuditRegistry` → npmjs。
- サプライチェーン対策の PR のため、third-party action は**フル SHA でピン留め**。

## スコープ外 / 非ゴール

- `publish.yaml` への適用 → 必要なら publish フローを個別検証のうえ別 PR
- bot-id による追跡ログ（DL トラッキング）→ 任意アップグレード

## テスト手順

- [ ] ci / chromatic / audit が緑（Takumi 経由 install が public PR の hardened mode 下でも成功する）
- [ ] audit が引き続き high 0 件で緑

## 実行したコマンド

- `YARN_NPM_REGISTRY_SERVER=https://npm.flatt.tech/ yarn npm audit --all --recursive --environment production --severity high` → **No audit suggestions（exit 0）**。`npmAuditRegistry` が npmjs に固定されることも確認
- `yarn prettier --check`（変更ファイル）→ OK
- ※ ソース（TS）は不変のため `build:all` / `type-check` / `test:ci` はローカル未実行（PR の CI で検証）
