### PR TITLE
276｜feat(dropdown,select,select-sort): match list item height to large size

### DIFF
--- a/docs/component/dropdown-specification.md
+++ b/docs/component/dropdown-specification.md
@@ -140,7 +140,7 @@ const items: DropdownItemType[] = [
 - 無効（`isDisabled: true`）: `buttonColors[variant].disabled` と `cursor-not-allowed` を適用し、`pointer-events-none` によりクリックできなくなる。
 - 矢印（`isArrowHidden: false`）: `Icon` を末尾に描画し、開閉状態で `angle-small-up`/`angle-small-down` を切り替える。
 
-`Dropdown.Menu` は `bg-uiBackground01`、`shadow-floatingShadow`、および `border-uiBorder01`（outlineバリアント時）で描画され、`overflow-y-auto` によって長いリストもスクロールできる。`Dropdown.Item` は `typography-label14regular`、`h-8`、`px-3` を基準とし、`focusVisible.inset` でフォーカスインジケータを持つ。
+`Dropdown.Menu` は `bg-uiBackground01`、`shadow-floatingShadow`、および `border-uiBorder01`（outlineバリアント時）で描画され、`overflow-y-auto` によって長いリストもスクロールできる。`Dropdown.Item` は `typography-label14regular`、`px-3` を基準とし、`focusVisible.inset` でフォーカスインジケータを持つ。item の高さは `size` に追従し、`size='large'` で `h-10`（40px）、それ以外（`x-small`/`small`/`medium`）では `h-8`（32px）となる。
 
 ### メニュー配置
 

--- a/docs/component/select-sort-specification.md
+++ b/docs/component/select-sort-specification.md
@@ -125,8 +125,8 @@ export const SortableHeader = () => {
 ### その他のスタイル仕様
 
 - ドロップダウン本体 (`SelectList`) は `absolute` でラッパー直下に重ね、`z-dropdown` と `shadow-floatingShadow` を付与する。`variant === 'outline'` の場合はボーダーが付く。
-- 選択肢 (`SelectItem`) は `li > button` 構造で `focusVisible.inset` を共有し、選択中は `bg-selectedUi` と `Icon name="check"` を表示する。
-- 「選択解除」ボタンは `typography-label14regular` の行高 32px (`h-8`) で、ホバー/アクティブ時に `hover:bg-hover02` / `active:bg-active02` を適用する。
+- 選択肢 (`SelectItem`) は `li > button` 構造で `focusVisible.inset` を共有し、選択中は `bg-selectedUi` と `Icon name="check"` を表示する。item の高さは `size` に追従し、`size='large'` で `h-10`（40px）、それ以外（`x-small`/`small`/`medium`）では `h-8`（32px）となる。
+- 「選択解除」ボタンは `typography-label14regular` で、行高は選択肢と揃え `size='large'` で `h-10`（40px）・それ以外で `h-8`（32px）とし、ホバー/アクティブ時に `hover:bg-hover02` / `active:bg-active02` を適用する。
 
 ## 使用例
 

--- a/docs/component/select-specification.md
+++ b/docs/component/select-specification.md
@@ -134,6 +134,8 @@ type SelectOption = {
 - タイポグラフィ: `typography-label16regular`
 - アイコンサイズ: `medium`
 
+上記の高さ・余白・タイポグラフィはトリガーボタンの仕様。オプションリストの各オプション (`Select.Option`) と「選択解除」ボタンの高さは `size` に追従し、`size='large'` で `h-10`（40px）、それ以外（`x-small`/`small`/`medium`）では `h-8`（32px）となる。
+
 ### バリアントスタイル
 
 #### outline（デフォルト）

--- a/packages/component-ui/src/dropdown/dropdown-context.ts
+++ b/packages/component-ui/src/dropdown/dropdown-context.ts
@@ -11,6 +11,7 @@ type UseDropdownReturnType = {
     height: number;
   };
   variant: 'text' | 'outline';
+  size: 'x-small' | 'small' | 'medium' | 'large';
 };
 
 export const DropdownContext = createContext<UseDropdownReturnType>({
@@ -19,4 +20,5 @@ export const DropdownContext = createContext<UseDropdownReturnType>({
   isDisabled: false,
   targetDimensions: { width: 0, height: 0 },
   variant: 'outline',
+  size: 'medium',
 });

--- a/packages/component-ui/src/dropdown/dropdown-item.tsx
+++ b/packages/component-ui/src/dropdown/dropdown-item.tsx
@@ -14,15 +14,17 @@ type Props = {
 };
 
 export function DropdownItem({ children, color = 'gray', onClick }: PropsWithChildren<Props>) {
-  const { setIsVisible } = useContext(DropdownContext);
+  const { setIsVisible, size } = useContext(DropdownContext);
   const handleClickItem = (event: MouseEvent<HTMLButtonElement>) => {
     setIsVisible(false);
     onClick?.(event);
   };
   const itemClasses = clsx(
-    'typography-label14regular flex h-8 w-full items-center px-3 hover:bg-hover02 active:bg-active02',
+    'typography-label14regular flex w-full items-center px-3 hover:bg-hover02 active:bg-active02',
     focusVisible.inset,
     {
+      'h-8': size !== 'large',
+      'h-10': size === 'large',
       'bg-uiBackground01 fill-icon01 text-interactive02': color === 'gray',
       'fill-supportDanger text-supportDanger': color === 'red',
     },

--- a/packages/component-ui/src/dropdown/dropdown.test.tsx
+++ b/packages/component-ui/src/dropdown/dropdown.test.tsx
@@ -29,4 +29,54 @@ describe('Dropdown', () => {
       });
     });
   });
+
+  describe('メニュー item の高さ', () => {
+    it('largeサイズでは item の高さが h-10 になること', () => {
+      render(
+        <Dropdown label="メニュー" size="large">
+          <Dropdown.Menu>
+            <Dropdown.Item>項目1</Dropdown.Item>
+          </Dropdown.Menu>
+        </Dropdown>,
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /メニュー/ }));
+
+      const itemButton = screen.getByText('項目1').closest('button');
+      expect(itemButton).toHaveClass('h-10');
+      expect(itemButton).not.toHaveClass('h-8');
+    });
+
+    it('mediumサイズ（デフォルト）では item の高さが h-8 になること', () => {
+      render(
+        <Dropdown label="メニュー">
+          <Dropdown.Menu>
+            <Dropdown.Item>項目1</Dropdown.Item>
+          </Dropdown.Menu>
+        </Dropdown>,
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /メニュー/ }));
+
+      const itemButton = screen.getByText('項目1').closest('button');
+      expect(itemButton).toHaveClass('h-8');
+      expect(itemButton).not.toHaveClass('h-10');
+    });
+
+    it('smallサイズでは item の高さが h-8 のまま維持されること', () => {
+      render(
+        <Dropdown label="メニュー" size="small">
+          <Dropdown.Menu>
+            <Dropdown.Item>項目1</Dropdown.Item>
+          </Dropdown.Menu>
+        </Dropdown>,
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /メニュー/ }));
+
+      const itemButton = screen.getByText('項目1').closest('button');
+      expect(itemButton).toHaveClass('h-8');
+      expect(itemButton).not.toHaveClass('h-10');
+    });
+  });
 });

--- a/packages/component-ui/src/dropdown/dropdown.tsx
+++ b/packages/component-ui/src/dropdown/dropdown.tsx
@@ -125,7 +125,7 @@ export function Dropdown({
 
   return (
     <DropdownContext.Provider
-      value={{ isVisible, setIsVisible, isDisabled, targetDimensions, variant, portalTargetRef }}
+      value={{ isVisible, setIsVisible, isDisabled, targetDimensions, variant, size, portalTargetRef }}
     >
       <div ref={targetRef} className={wrapperClasses}>
         {target ? (

--- a/packages/component-ui/src/select-sort/select-item.tsx
+++ b/packages/component-ui/src/select-sort/select-item.tsx
@@ -7,15 +7,19 @@ import { Icon } from '../icon';
 type Props = {
   /** 選択済みの並び替え方向かどうか。チェックアイコンや背景色を切り替える。 */
   isSortKey: boolean;
+  /** 表示中の SelectSort と同期させるサイズ。リスト item の高さに反映される。 */
+  size: 'x-small' | 'small' | 'medium' | 'large';
   /** ボタンを押したときに並び替え方向を親へ通知する処理。 */
   onClickItem: () => void;
 };
 
-export function SelectItem({ children, isSortKey, onClickItem }: PropsWithChildren<Props>) {
+export function SelectItem({ children, isSortKey, size, onClickItem }: PropsWithChildren<Props>) {
   const itemClasses = clsx(
-    'typography-label14regular flex h-8 w-full items-center px-3 hover:bg-hover02 active:bg-active02',
+    'typography-label14regular flex w-full items-center px-3 hover:bg-hover02 active:bg-active02',
     focusVisible.inset,
     {
+      'h-8': size !== 'large',
+      'h-10': size === 'large',
       'bg-selectedUi fill-interactive01 text-interactive01': isSortKey,
       'bg-uiBackground01 fill-icon01 text-interactive02': !isSortKey,
     },

--- a/packages/component-ui/src/select-sort/select-list.tsx
+++ b/packages/component-ui/src/select-sort/select-list.tsx
@@ -29,16 +29,20 @@ export function SelectList({ size, variant, sortOrder, onClickItem, onClickDesel
   );
 
   const deselectButtonClasses = clsx(
-    'typography-label14regular flex h-8 w-full items-center px-3 text-interactive02 hover:bg-hover02 active:bg-active02',
+    'typography-label14regular flex w-full items-center px-3 text-interactive02 hover:bg-hover02 active:bg-active02',
     focusVisible.inset,
+    {
+      'h-8': size !== 'large',
+      'h-10': size === 'large',
+    },
   );
 
   return (
     <ul className={listClasses}>
-      <SelectItem isSortKey={sortOrder === 'ascend'} onClickItem={() => onClickItem('ascend')}>
+      <SelectItem size={size} isSortKey={sortOrder === 'ascend'} onClickItem={() => onClickItem('ascend')}>
         昇順で並び替え
       </SelectItem>
-      <SelectItem isSortKey={sortOrder === 'descend'} onClickItem={() => onClickItem('descend')}>
+      <SelectItem size={size} isSortKey={sortOrder === 'descend'} onClickItem={() => onClickItem('descend')}>
         降順で並び替え
       </SelectItem>
       {sortOrder !== null && onClickDeselect && (

--- a/packages/component-ui/src/select-sort/select-sort.test.tsx
+++ b/packages/component-ui/src/select-sort/select-sort.test.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { MODAL_OPEN_EVENT } from '../hooks/use-dismiss-on-modal-open';
 import { SelectSort } from './select-sort';
@@ -20,6 +20,58 @@ describe('SelectSort', () => {
       await waitFor(() => {
         expect(screen.queryByRole('list')).not.toBeInTheDocument();
       });
+    });
+  });
+
+  describe('リスト item の高さ', () => {
+    it('largeサイズでは item の高さが h-10 になること', () => {
+      render(<SelectSort label="氏名" sortOrder={null} size="large" />);
+
+      fireEvent.click(screen.getByRole('button', { name: /氏名/ }));
+
+      const itemButton = screen.getByText('昇順で並び替え').closest('button');
+      expect(itemButton).toHaveClass('h-10');
+      expect(itemButton).not.toHaveClass('h-8');
+    });
+
+    it('mediumサイズ（デフォルト）では item の高さが h-8 になること', () => {
+      render(<SelectSort label="氏名" sortOrder={null} />);
+
+      fireEvent.click(screen.getByRole('button', { name: /氏名/ }));
+
+      const itemButton = screen.getByText('昇順で並び替え').closest('button');
+      expect(itemButton).toHaveClass('h-8');
+      expect(itemButton).not.toHaveClass('h-10');
+    });
+
+    it('smallサイズでは item の高さが h-8 のまま維持されること', () => {
+      render(<SelectSort label="氏名" sortOrder={null} size="small" />);
+
+      fireEvent.click(screen.getByRole('button', { name: /氏名/ }));
+
+      const itemButton = screen.getByText('昇順で並び替え').closest('button');
+      expect(itemButton).toHaveClass('h-8');
+      expect(itemButton).not.toHaveClass('h-10');
+    });
+
+    it('largeサイズでは選択解除ボタンの高さが h-10 になること', () => {
+      render(<SelectSort label="氏名" sortOrder="ascend" size="large" onClickDeselect={vi.fn()} />);
+
+      fireEvent.click(screen.getByRole('button', { name: /氏名/ }));
+
+      const deselectButton = screen.getByText('選択解除').closest('button');
+      expect(deselectButton).toHaveClass('h-10');
+      expect(deselectButton).not.toHaveClass('h-8');
+    });
+
+    it('mediumサイズでは選択解除ボタンの高さが h-8 のまま維持されること', () => {
+      render(<SelectSort label="氏名" sortOrder="ascend" onClickDeselect={vi.fn()} />);
+
+      fireEvent.click(screen.getByRole('button', { name: /氏名/ }));
+
+      const deselectButton = screen.getByText('選択解除').closest('button');
+      expect(deselectButton).toHaveClass('h-8');
+      expect(deselectButton).not.toHaveClass('h-10');
     });
   });
 });

--- a/packages/component-ui/src/select/select-item.tsx
+++ b/packages/component-ui/src/select/select-item.tsx
@@ -11,7 +11,7 @@ type Props = {
 };
 
 export function SelectItem({ option }: Props) {
-  const { setIsOptionListOpen, selectedOption, onChange, isError } = useContext(SelectContext);
+  const { setIsOptionListOpen, selectedOption, onChange, isError, size } = useContext(SelectContext);
 
   const handleClickItem = (option: SelectOption) => {
     onChange?.(option);
@@ -19,9 +19,11 @@ export function SelectItem({ option }: Props) {
   };
 
   const itemClasses = clsx(
-    'typography-label14regular flex h-8 w-full items-center px-3 hover:bg-hover02 active:bg-active02',
+    'typography-label14regular flex w-full items-center px-3 hover:bg-hover02 active:bg-active02',
     focusVisible.inset,
     {
+      'h-8': size !== 'large',
+      'h-10': size === 'large',
       'text-interactive01 fill-interactive01 bg-selectedUi': option.id === selectedOption?.id && !(isError ?? false),
       'text-supportError fill-supportError bg-uiBackgroundError': option.id === selectedOption?.id && isError,
       'text-interactive02 fill-icon01 bg-uiBackground01': option.id !== selectedOption?.id,

--- a/packages/component-ui/src/select/select-list.tsx
+++ b/packages/component-ui/src/select/select-list.tsx
@@ -10,7 +10,7 @@ type Props = {
 };
 
 export const SelectList = forwardRef<HTMLUListElement, PropsWithChildren<Props>>(({ children, maxHeight }, ref) => {
-  const { selectedOption, setIsOptionListOpen, variant, placeholder, onChange, floatingStyles, floatingRef } =
+  const { selectedOption, setIsOptionListOpen, variant, placeholder, onChange, floatingStyles, floatingRef, size } =
     useContext(SelectContext);
 
   const handleClickDeselect = () => {
@@ -48,8 +48,12 @@ export const SelectList = forwardRef<HTMLUListElement, PropsWithChildren<Props>>
   });
 
   const deselectButtonClasses = clsx(
-    'typography-label14regular flex h-8 w-full items-center px-3 text-interactive02 hover:bg-hover02 active:bg-active02',
+    'typography-label14regular flex w-full items-center px-3 text-interactive02 hover:bg-hover02 active:bg-active02',
     focusVisible.inset,
+    {
+      'h-8': size !== 'large',
+      'h-10': size === 'large',
+    },
   );
 
   return (

--- a/packages/component-ui/src/select/select.test.tsx
+++ b/packages/component-ui/src/select/select.test.tsx
@@ -210,6 +210,63 @@ describe('Select', () => {
     });
   });
 
+  describe('オプションリストの item 高さ', () => {
+    it('largeサイズではオプションの高さが h-10 になること', () => {
+      render(<SelectTestComponent size="large" />);
+      const selectButton = screen.getByRole('button');
+
+      fireEvent.click(selectButton);
+
+      const optionButton = screen.getByText('選択肢A').closest('button');
+      expect(optionButton).toHaveClass('h-10');
+      expect(optionButton).not.toHaveClass('h-8');
+    });
+
+    it('mediumサイズ（デフォルト）ではオプションの高さが h-8 になること', () => {
+      render(<SelectTestComponent />);
+      const selectButton = screen.getByRole('button');
+
+      fireEvent.click(selectButton);
+
+      const optionButton = screen.getByText('選択肢A').closest('button');
+      expect(optionButton).toHaveClass('h-8');
+      expect(optionButton).not.toHaveClass('h-10');
+    });
+
+    it('smallサイズではオプションの高さが h-8 のまま維持されること', () => {
+      render(<SelectTestComponent size="small" />);
+      const selectButton = screen.getByRole('button');
+
+      fireEvent.click(selectButton);
+
+      const optionButton = screen.getByText('選択肢A').closest('button');
+      expect(optionButton).toHaveClass('h-8');
+      expect(optionButton).not.toHaveClass('h-10');
+    });
+
+    it('largeサイズでは選択解除ボタンの高さが h-10 になること', () => {
+      render(<SelectTestComponent size="large" placeholder="選択" initialOption={testOptions[1]} />);
+      const selectButton = screen.getByRole('button');
+
+      fireEvent.click(selectButton);
+
+      const deselectButton = screen.getByText('選択解除').closest('button');
+      expect(deselectButton).toHaveClass('h-10');
+      expect(deselectButton).not.toHaveClass('h-8');
+    });
+
+    it('mediumサイズでは選択解除ボタンの高さが h-8 のまま維持されること', () => {
+      render(<SelectTestComponent placeholder="選択" initialOption={testOptions[1]} />);
+      const selectButton = screen.getByRole('button');
+
+      fireEvent.click(selectButton);
+
+      const deselectButton = screen.getByText('選択解除').closest('button');
+      expect(deselectButton).toHaveClass('h-8');
+      expect(deselectButton).not.toHaveClass('h-10');
+    });
+  });
+
   describe('バリアント', () => {
     it('outlineバリアント（デフォルト）でボーダーが表示されること', () => {
       render(<SelectTestComponent />);


### PR DESCRIPTION
## 概要

`Dropdown` / `Select` / `SelectSort` の 3 コンポーネントについて、`size="large"` 指定時にリスト（メニュー／オプション）の各 item の高さを Figma 仕様（40px）に合わせて切り替えるようにしました。これまで item の高さは size 非連動で常に `h-8`（32px）固定でした。

## 設計判断

- **List 実装の独立性を維持**: 3 コンポーネントの List 実装は各々独立しているため、共通化・List コンポーネント化は行わず、各コンポーネント内で size を item まで伝播させる方針としました。
- **高さ制御方式**: Figma は padding ベースですが、既存コードが高さ固定（`h-8`）方式のため、最小差分かつ一貫性が高い `h-8`/`h-10` 切替で実装しました。
- **`h-8` ハードコードの完全置換**: `h-8` を残したまま `h-10` を条件追加すると Tailwind の生成順により意図しない高さになる恐れがあるため、`clsx` の条件分岐（`'h-8': size !== 'large'` / `'h-10': size === 'large'`）へ完全置換しています。
- **large のみ変更**: Figma 上 Medium item は 32px のため medium は据え置き。small/x-small は専用定義が無く現行 32px を維持。large のみ 40px に連動させます。typography・アイコンサイズ・横 padding・gap は変更していません。

## 変更内容

| ファイル | 内容 |
|---|---|
| `dropdown/dropdown-context.ts` | Context に `size` を追加（default `'medium'`） |
| `dropdown/dropdown.tsx` | `DropdownContext.Provider` の value に `size` を追加 |
| `dropdown/dropdown-item.tsx` | Context から `size` を取得し item 高さを large 時 `h-10` に切替 |
| `select/select-item.tsx` | Context の `size` で item 高さを large 時 `h-10` に切替 |
| `select/select-list.tsx` | 「選択解除」ボタンの高さを large 時 `h-10` に切替 |
| `select-sort/select-item.tsx` | `size` props を追加し item 高さを large 時 `h-10` に切替 |
| `select-sort/select-list.tsx` | `SelectItem` への `size` 受け渡しと「選択解除」ボタンの高さ切替 |
| `*/​*.test.tsx`（3 ファイル） | large/medium/small の item・選択解除ボタン高さ検証を追加 |
| `docs/component/*-specification.md`（3 ファイル） | item・選択解除ボタンの高さが size 追従する旨へ記述を更新 |

## 影響範囲

- 破壊的変更は**なし**（視覚的変更のみ）。公開 props の追加・変更はありません（`size` は既存）。
- `size="large"` を使っている呼び出し元では List item の高さが 32px→40px に変わります（意図された変更）。`size` 未指定／large 以外は従来と完全に同一です。
- `Dropdown` のみ Context に `size` を追加していますが、内部実装で外部非公開です。

## スコープ外 / 非ゴール

- small / x-small 用の List item 寸法の定義（Figma に専用定義が無いため現行 32px を維持）。
- 3 コンポーネントの List 実装の共通化。

## テスト観点

- `size="large"` で item の `<button>` が `h-10` を持ち `h-8` を持たないこと。
- `size` 未指定（medium）・`small` で従来どおり `h-8` を維持すること。
- Select / SelectSort の「選択解除」ボタンも large で `h-10`・medium で `h-8` になること。

## テスト手順

- [ ] `Dropdown` / `Select` / `SelectSort` を `size="large"` でリスト展開し、各 item の高さが 40px になることを確認
- [ ] `size` 未指定・`small` ではリスト item の高さが従来どおり 32px であることを確認
- [ ] Select / SelectSort で選択中のとき表示される「選択解除」ボタンの高さが item と揃うことを確認

## 実行したコマンド

- `yarn build:all` — OK
- `yarn lint` — eslint OK / 変更ファイルの prettier OK（全体の prettier は `tmp/` 配下の既存未フォーマット md により FAIL するが本変更とは無関係）
- `yarn type-check` — OK
- `yarn test:ci` — 497 passed / 2 skipped
