### PR TITLE
ci(audit): temporarily ignore esbuild advisory 1120679

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -50,5 +50,8 @@ jobs:
         uses: ./.github/actions/yarn-install
 
       # production 依存に high 以上の脆弱性が見つかった場合はジョブを失敗させる。
+      # 1120679: esbuild@0.27.7 (GHSA-gv7w-rqvm-qjhr) — tsup@8.5.1 の依存。Deno 向けバイナリの問題で
+      # Node.js ビルドツールとしての利用には影響しない。tsup が esbuild@>=0.28.1 に対応した
+      # バージョンをリリースし Renovate が更新 PR を出したタイミングで除外を削除する。
       - name: Audit production dependencies (high and above)
-        run: yarn npm audit --all --recursive --environment production --severity high
+        run: yarn npm audit --all --recursive --environment production --severity high --ignore 1120679

--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -53,5 +53,21 @@ jobs:
       # 1120679: esbuild@0.27.7 (GHSA-gv7w-rqvm-qjhr) — tsup@8.5.1 の依存。Deno 向けバイナリの問題で
       # Node.js ビルドツールとしての利用には影響しない。tsup が esbuild@>=0.28.1 に対応した
       # バージョンをリリースし Renovate が更新 PR を出したタイミングで除外を削除する。
+      - name: Ensure esbuild audit ignore is still needed
+        run: |
+          set +e
+          audit_output=$(yarn npm audit --all --recursive --environment production --severity high --json 2>&1)
+          audit_status=$?
+          set -e
+
+          if [ "$audit_status" -eq 0 ]; then
+            echo "::error::Remove --ignore 1120679 because advisory 1120679 no longer affects production dependencies."
+            exit 1
+          fi
+
+          if echo "$audit_output" | grep -Eq '"ID":[[:space:]]*1120679'; then
+            exit 0
+          fi
+
       - name: Audit production dependencies (high and above)
         run: yarn npm audit --all --recursive --environment production --severity high --ignore 1120679


### PR DESCRIPTION
> [!NOTE]
> - 現在、workflows で npm audit を実行するようにし high以上がある場合はマージできないようなっている
> - 検出に対する対応

## 概要

`tsup@8.5.1` 経由で検出される `esbuild@0.27.7` の advisory（GHSA-gv7w-rqvm-qjhr / ID: 1120679）を、production audit で一時的に除外します。

あわせて、`--ignore 1120679` が不要になったタイミングを CI で検知する guard step を追加します。これにより、Renovate で `tsup` 側の対応版が入った後に除外設定が残り続けることを防ぎます。

## 変更内容

- `yarn npm audit --all --recursive --environment production --severity high` に `--ignore 1120679` を追加
- ignore なし audit の JSON 出力を確認する `Ensure esbuild audit ignore is still needed` step を追加
- `1120679` が解消されて ignore なし audit が通るようになった場合、CI を失敗させて除外削除を促す

## 背景

- 対象 advisory: GHSA-gv7w-rqvm-qjhr / ID: 1120679
- 影響範囲: `esbuild >=0.17.0 <0.28.1`
- patched version: `esbuild@0.28.1`
- 現在の検出経路: `tsup@8.5.1 -> esbuild@0.27.7`
- 内容は Deno module の binary integrity verification 欠如であり、このリポジトリでの Node.js ビルドツール用途には直接影響しないと判断
- 現時点で `tsup` latest は `8.5.1` のままで、依存更新だけでは解消できない

## 解除条件

`tsup` が `esbuild@0.28.1` 以降を解決できるバージョンに更新され、ignore なし audit が通るようになったら `--ignore 1120679` と guard step を削除します。

## 実行したコマンド

```bash
yarn npm audit --all --recursive --environment production --severity high --ignore 1120679
git diff --check
```

追加した guard script 相当もローカルで実行し、現在の依存状態では exit code 0 になることを確認しています.