### PR TITLE
fix(audit): bump undici to patch advisories and drop withdrawn esbuild ignore

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -50,24 +50,5 @@ jobs:
         uses: ./.github/actions/yarn-install
 
       # production 依存に high 以上の脆弱性が見つかった場合はジョブを失敗させる。
-      # 1120679: esbuild@0.27.7 (GHSA-gv7w-rqvm-qjhr) — tsup@8.5.1 の依存。Deno 向けバイナリの問題で
-      # Node.js ビルドツールとしての利用には影響しない。tsup が esbuild@>=0.28.1 に対応した
-      # バージョンをリリースし Renovate が更新 PR を出したタイミングで除外を削除する。
-      - name: Ensure esbuild audit ignore is still needed
-        run: |
-          set +e
-          audit_output=$(yarn npm audit --all --recursive --environment production --severity high --json 2>&1)
-          audit_status=$?
-          set -e
-
-          if [ "$audit_status" -eq 0 ]; then
-            echo "::error::Remove --ignore 1120679 because advisory 1120679 no longer affects production dependencies."
-            exit 1
-          fi
-
-          if echo "$audit_output" | grep -Eq '"ID":[[:space:]]*1120679'; then
-            exit 0
-          fi
-
       - name: Audit production dependencies (high and above)
-        run: yarn npm audit --all --recursive --environment production --severity high --ignore 1120679
+        run: yarn npm audit --all --recursive --environment production --severity high

--- a/yarn.lock
+++ b/yarn.lock
@@ -9244,16 +9244,16 @@ __metadata:
   linkType: hard
 
 "undici@npm:^6.25.0":
-  version: 6.26.0
-  resolution: "undici@npm:6.26.0"
-  checksum: 10c0/cf2b4caf58c33d6582970991290cc7a6486d6e738845f25dcdd16952d708ec844815c6d30362919764fcaf30f719891289341f1ada496f003ce2700310453a47
+  version: 6.27.0
+  resolution: "undici@npm:6.27.0"
+  checksum: 10c0/f88c3dae3957dbf9d93cb481440aced317bd3c4941b5914fea5efba516d51138988cdb5c76006f0bb1337e41d56c3443351055d492e73af2428521c37ba2a76f
   languageName: node
   linkType: hard
 
 "undici@npm:^7.19.0":
-  version: 7.27.2
-  resolution: "undici@npm:7.27.2"
-  checksum: 10c0/714632147c80eb8eda8a52df51b481d346df5e035ccc1d87eb3bbcb8f92ec25d7cbbe81abdeae5db4e37a93e490c8d2fa2359ecdca4b2c5c6c513dcd2626ad47
+  version: 7.28.0
+  resolution: "undici@npm:7.28.0"
+  checksum: 10c0/fe781983a26098795e99bb1f64906cbb7d0bcaa029a26baade007b53ea67f2631d189b8f9671a31f4c8d0cb3773b7559608628ba54452fef51fec90e7c78bb0d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 概要

main の `Audit` ジョブが、新規公開された undici の high 脆弱性で失敗していたため、undici を修正版へ更新して解消する。あわせて、既に撤回（Withdrawn）された esbuild advisory `1120679` 向けの除外設定が不要になったため削除する。

## 問題

`main` push および日次 cron の `Audit` ジョブが失敗していた（production 依存に high 脆弱性を検知）。

検知された undici advisory（いずれも high）:

| 経路 | undici | advisory |
|---|---|---|
| `cheerio@1.2.0`（`component-icons` の devDependency） | 7.27.2 | 1121187 / 1121244 / 1121247 |
| `node-gyp@13.0.0`（`fsevents` 経由） | 6.26.0 | 1121245 |

## 原因

1. 上流で undici の high advisory が複数公開され、lockfile が脆弱なバージョン（7.27.2 / 6.26.0）に固定されたままだった。
2. 修正版は各依存元の宣言済み semver 範囲内に存在していた（`cheerio`: `undici@^7.19.0` → 7.28.0、`node-gyp`: `undici@^6.25.0` → 6.27.0）ため、lockfile が古いだけだった。

## 修正内容

### 1. undici を範囲内最新へ更新（`yarn.lock` のみ）

`yarn up -R undici` で lockfile の undici を更新:

- `undici 7.27.2 → 7.28.0`（`cheerio` 経路。`^7.19.0` の範囲内）
- `undici 6.26.0 → 6.27.0`（`node-gyp` 経路。`^6.25.0` の範囲内）

両方とも宣言済み範囲内のため `resolutions` での強制は不要。`package.json` の `resolutions` は変更していない（恒久的なピン留めを増やさない方針）。今後の追従は Renovate の lockfile maintenance に委ねられる。

### 2. 撤回済み esbuild advisory `1120679` の除外を削除（`.github/workflows/audit.yaml`）

`--ignore 1120679` と、その除外が不要になったことを検知する「Ensure esbuild audit ignore is still needed」ガードステップを削除した。

調査の結果、`1120679`（GHSA-gv7w-rqvm-qjhr）は**上流で撤回（Withdrawn）済み**であり、現在は全環境・全 severity の audit で 0 件だった。経緯は以下のとおり:

| 日時 (JST) | 出来事 |
|---|---|
| 2026-06-13 05:08 | advisory 公開（esbuild の Deno モジュールにおける RCE 懸念） |
| 2026-06-17 09:35 | 本リポジトリで `--ignore 1120679` を追加 |
| 2026-06-17 22:42 | **GitHub 側が advisory を撤回（Withdrawn）** ← 除外追加の約13時間後 |

advisory の summary は現在 `"Withdrawn Advisory: ..."` となっており、当初の見立て（Deno 向けバイナリ固有で Node.js ビルドツール用途には影響しない）が撤回理由と一致する。除外はほぼ即座に不要化していたことになる。undici を修正したことで production audit が完全クリーンになり、設計どおり当該ガードステップが「除外を削除せよ」と検知する状態になっていた。

## 影響範囲

- ライブラリの公開 API・成果物への影響なし。undici は `component-icons` のアイコン生成（`cheerio`）および `fsevents`（`node-gyp`）の build/optional 経由で、いずれも公開パッケージには同梱されない。
- 破壊的変更なし。

## スコープ外 / 非ゴール

- undici 以外の依存更新は行わない。
- 監査ワークフローの構成変更（しきい値・対象範囲等）は行わない。今回は陳腐化した除外の撤去のみ。

## テスト手順

- [ ] `Audit` ジョブがグリーンになること（production / high / 除外なし で 0 件）
- [ ] 既存の build / lint / type-check / test に影響がないこと

## 実行したコマンド

- `yarn npm audit --all --recursive --environment production --severity high` — `No audit suggestions`（exit 0）
- `yarn build:all` — OK
- `yarn lint` — OK（`tmp/` 配下の未追跡ファイルへの警告のみ。変更対象の `audit.yaml` は適合）
- `yarn type-check` — OK
- `yarn test:ci` — 644 passed / 2 skipped
