### PR TITLE
319｜fix(color): restore blue50 token to #177ee5

### DIFF
--- a/packages/component-config/src/tokens/tokens.ts
+++ b/packages/component-config/src/tokens/tokens.ts
@@ -31,7 +31,7 @@ export const tokens = {
       "textBlack": "#000000"
     },
     "link": {
-      "link01": "#0077d9",
+      "link01": "#177ee5",
       "link02": "#a4a5a6"
     },
     "border": {
@@ -61,10 +61,10 @@ export const tokens = {
       "iconOnColor": "#ffffff"
     },
     "interactive": {
-      "interactive01": "#0077d9",
-      "interactiveBg01": "#0077d9",
+      "interactive01": "#177ee5",
+      "interactiveBg01": "#177ee5",
       "interactive02": "#5c6366",
-      "interactive03": "#0077d9",
+      "interactive03": "#177ee5",
       "interactive04": "#cacccd"
     },
     "field": {
@@ -72,7 +72,7 @@ export const tokens = {
       "fieldSearch": "#ffffff"
     },
     "focus": {
-      "focus": "#0077d9"
+      "focus": "#177ee5"
     },
     "hover": {
       "hover01": "#1366b9",
@@ -95,7 +95,7 @@ export const tokens = {
       "active02": "#cacccd",
       "active02Background": "#dedfe0",
       "activeUi": "#d9eafb",
-      "activeSelectedUi": "#0077d9",
+      "activeSelectedUi": "#177ee5",
       "activeDanger": "#821732",
       "activeInput": "#1366b9",
       "activeLink01": "#0e4b87",
@@ -106,7 +106,7 @@ export const tokens = {
       "selectedUi": "#f1f7fd",
       "selectedUiGray": "#dedfe0",
       "selectedUiOnColor": "#ffffff",
-      "selectedUiBorder": "#0077d9",
+      "selectedUiBorder": "#177ee5",
       "selectedUiDark": "#1366b9"
     },
     "disabled": {
@@ -123,7 +123,7 @@ export const tokens = {
       "supportErrorLight": "#f4bfcd",
       "supportSuccess": "#29b471",
       "supportSuccessLight": "#ccf4e1",
-      "supportInfo": "#0077d9",
+      "supportInfo": "#177ee5",
       "supportInfoLight": "#b9d8f7",
       "supportWarning": "#fcd200",
       "supportWarningLight": "#fff4ba",
@@ -139,7 +139,7 @@ export const tokens = {
       "blue20": "#d9eafb",
       "blue30": "#9fcbf5",
       "blue40": "#60a8ef",
-      "blue50": "#0077d9",
+      "blue50": "#177ee5",
       "blue60": "#1571ce",
       "blue70": "#1366b9",
       "blue80": "#115ca7",
@@ -607,7 +607,7 @@ export const tokensWithMeta = {
     },
     "link": {
       "link01": {
-        "value": "#0077d9",
+        "value": "#177ee5",
         "description": "Primary links",
         "type": "color",
         "rawValue": "$Colors.Blue.Blue50"
@@ -747,13 +747,13 @@ export const tokensWithMeta = {
     },
     "interactive": {
       "interactive01": {
-        "value": "#0077d9",
+        "value": "#177ee5",
         "description": "Primary Interactive color, Primary buttons",
         "type": "color",
         "rawValue": "$Colors.Blue.Blue50"
       },
       "interactiveBg01": {
-        "value": "#0077d9",
+        "value": "#177ee5",
         "description": "Primary Interactive color on background, Primary fill buttons",
         "type": "color",
         "rawValue": "$Colors.Blue.Blue50"
@@ -765,7 +765,7 @@ export const tokensWithMeta = {
         "rawValue": "$Colors.Gray.Gray80"
       },
       "interactive03": {
-        "value": "#0077d9",
+        "value": "#177ee5",
         "description": "Tertiary button, Selected elements, Active elements, Accent icon",
         "type": "color",
         "rawValue": "$Colors.Blue.Blue50"
@@ -793,7 +793,7 @@ export const tokensWithMeta = {
     },
     "focus": {
       "focus": {
-        "value": "#0077d9",
+        "value": "#177ee5",
         "description": "Focus border, Focus underline",
         "type": "color",
         "rawValue": "$Colors.Blue.Blue50"
@@ -911,7 +911,7 @@ export const tokensWithMeta = {
         "rawValue": "$Colors.Blue.Blue20"
       },
       "activeSelectedUi": {
-        "value": "#0077d9",
+        "value": "#177ee5",
         "description": "Checkbox background color, Select border color",
         "type": "color",
         "rawValue": "$Colors.Blue.Blue50"
@@ -967,7 +967,7 @@ export const tokensWithMeta = {
         "rawValue": "$Colors.White"
       },
       "selectedUiBorder": {
-        "value": "#0077d9",
+        "value": "#177ee5",
         "description": "Selected Button Border",
         "type": "color",
         "rawValue": "$Colors.Blue.Blue50"
@@ -1047,7 +1047,7 @@ export const tokensWithMeta = {
         "type": "color"
       },
       "supportInfo": {
-        "value": "#0077d9",
+        "value": "#177ee5",
         "description": "Information text, button background, button border",
         "type": "color",
         "rawValue": "$Colors.Blue.Blue50"
@@ -1113,7 +1113,7 @@ export const tokensWithMeta = {
         "type": "color"
       },
       "blue50": {
-        "value": "#0077d9",
+        "value": "#177ee5",
         "description": "",
         "type": "color"
       },

--- a/packages/component-config/style-dictionary/tokens.json
+++ b/packages/component-config/style-dictionary/tokens.json
@@ -610,7 +610,7 @@
           "description": ""
         },
         "Blue50": {
-          "value": "#0077D9",
+          "value": "#177EE5",
           "type": "color",
           "description": ""
         },

--- a/packages/component-config/style-dictionary/transformed-tokens.json
+++ b/packages/component-config/style-dictionary/transformed-tokens.json
@@ -142,7 +142,7 @@
     },
     "Link": {
       "Link01": {
-        "value": "#0077D9",
+        "value": "#177EE5",
         "type": "color",
         "description": "Primary links",
         "rawValue": "$Colors.Blue.Blue50"
@@ -282,13 +282,13 @@
     },
     "Interactive": {
       "Interactive01": {
-        "value": "#0077D9",
+        "value": "#177EE5",
         "type": "color",
         "description": "Primary Interactive color, Primary buttons",
         "rawValue": "$Colors.Blue.Blue50"
       },
       "InteractiveBg01": {
-        "value": "#0077D9",
+        "value": "#177EE5",
         "type": "color",
         "description": "Primary Interactive color on background, Primary fill buttons",
         "rawValue": "$Colors.Blue.Blue50"
@@ -300,7 +300,7 @@
         "rawValue": "$Colors.Gray.Gray80"
       },
       "Interactive03": {
-        "value": "#0077D9",
+        "value": "#177EE5",
         "type": "color",
         "description": "Tertiary button, Selected elements, Active elements, Accent icon",
         "rawValue": "$Colors.Blue.Blue50"
@@ -328,7 +328,7 @@
     },
     "Focus": {
       "Focus": {
-        "value": "#0077D9",
+        "value": "#177EE5",
         "type": "color",
         "description": "Focus border, Focus underline",
         "rawValue": "$Colors.Blue.Blue50"
@@ -446,7 +446,7 @@
         "rawValue": "$Colors.Blue.Blue20"
       },
       "ActiveSelectedUi": {
-        "value": "#0077D9",
+        "value": "#177EE5",
         "type": "color",
         "description": "Checkbox background color, Select border color",
         "rawValue": "$Colors.Blue.Blue50"
@@ -502,7 +502,7 @@
         "rawValue": "$Colors.White"
       },
       "SelectedUiBorder": {
-        "value": "#0077D9",
+        "value": "#177EE5",
         "type": "color",
         "description": "Selected Button Border",
         "rawValue": "$Colors.Blue.Blue50"
@@ -584,7 +584,7 @@
         "rawValue": "#CCF4E1"
       },
       "SupportInfo": {
-        "value": "#0077D9",
+        "value": "#177EE5",
         "type": "color",
         "description": "Information text, button background, button border",
         "rawValue": "$Colors.Blue.Blue50"
@@ -659,10 +659,10 @@
         "rawValue": "#60A8EF"
       },
       "Blue50": {
-        "value": "#0077D9",
+        "value": "#177EE5",
         "type": "color",
         "description": "",
-        "rawValue": "#0077D9"
+        "rawValue": "#177EE5"
       },
       "Blue60": {
         "value": "#1571CE",

--- a/packages/component-ui/src/color/color.stories.tsx
+++ b/packages/component-ui/src/color/color.stories.tsx
@@ -7,7 +7,11 @@ const meta: Meta = {
   title: 'Tokens/Color',
 };
 
-const version = 2;
+// Chromatic の TurboSnap は変更ファイルに依存する Story のみ再撮影するため、
+// トークン定義（component-config）だけを変更するとこの Story の差分が検知されない。
+// トークンの色変更時にこの値をインクリメントして Story 自体に差分を作り、
+// 再撮影を強制するためのマーカー。
+const version = 3;
 
 export default meta;
 type Story = StoryObj;


### PR DESCRIPTION
> [!NOTE]
> - #485 で実施した Blue50 の色変更を元の値に戻す対応です。
> - `git revert` ではなく前向きの追加コミットで戻しています（理由は「なぜ revert ではないか」参照）。

## 概要

- #485 でコントラスト改善のため Blue50 を `#177ee5` → `#0077d9` に変更しましたが、元の `#177ee5` に戻します。 
- `#177ee5` がアプリケーションのキーカラーであったため、変更するには問題があったため

## 問題

#485 の Blue50 変更により、別の都合で不都合が生じたため、色変更を取り消す必要が出ました。

## 修正内容

- トークンソース `packages/component-config/style-dictionary/tokens.json` の Blue50 を `#177EE5` に戻しました。
- `yarn build:tokens` を実行し、生成物（`tokens.ts` / `transformed-tokens.json`）を再生成しています。
- Blue50 を参照するセマンティックトークンは参照解決により自動で復元されます。
- Chromatic（TurboSnap）の差分検知のため `packages/component-ui/src/color/color.stories.tsx` の `version` をインクリメントし、あわせて値の意図を説明するコメントを追記しました。

### 復元されるトークン（`#0077d9` → `#177ee5`）

| token | 戻り値 |
| --- | --- |
| link.link01 | #177ee5 |
| interactive.interactive01 | #177ee5 |
| interactive.interactiveBg01 | #177ee5 |
| interactive.interactive03 | #177ee5 |
| focus.focus | #177ee5 |
| active.activeSelectedUi | #177ee5 |
| selected.selectedUiBorder | #177ee5 |
| support.supportInfo | #177ee5 |
| palette.blue.blue50 | #177ee5 |

## なぜ revert ではないか

#485 のマージ後、`tokens.json` には別件の後続コミット（SupportSuccess の値更新、UI states の説明更新、HoverUiError/ActiveUiError/SelectedUi の修正、SelectedUiDark 追加 等）が複数積まれています。`git revert`（#485 のマージコミット）ではこれら無関係なトークン作業まで巻き戻る／コンフリクトするため、Blue50 の値のみを前向きに戻す追加コミットとしています。

## 影響範囲

- 上表のトークンを利用しているコンポーネント（Button / Checkbox / Select / Link 系など Blue50 由来色を使う箇所）の表示色が `#177ee5` に戻ります。
- 公開 API の変更はありません（色値のみ）。

## スコープ外 / 非ゴール

- コントラスト改善そのものの再検討（別途対応）。

## スクリーンショット / Storybook

- Storybook の `Tokens/Color` で復元後の色を確認できます。

## 実行したコマンド

- `yarn build:all` — OK
- `yarn lint` — OK（変更ファイルは Prettier / ESLint クリーン）
- `yarn type-check` — OK
- `yarn test:ci` — 644 passed / 2 skipped
