### PR TITLE
chore(stories): add time selection experiment stories

### DIFF
--- a/packages/component-ui/src/combobox/combobox.stories.tsx
+++ b/packages/component-ui/src/combobox/combobox.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { expect, userEvent, within } from 'storybook/test';
 
 import { Button } from '../button';
 import { Modal } from '../modal';
@@ -1150,4 +1151,379 @@ export const WithinPopover: Story = {
       </div>
     );
   },
+};
+
+/**
+ * 時刻選択（HH:mm）を 1 つの Combobox で構成するサンプル（実験実装フェーズの検証用）。
+ *
+ * `docs/time-input-component-design-best-practices.md` の combo box 型（§3.2 USWDS / §2.9）を踏襲:
+ * - `step`（既定 15 分）で `HH:mm` 候補を自動生成（24h）
+ * - テキスト入力でインクリメンタルに絞り込み（`09`・`0930`・`09:30` のいずれでもヒット）
+ * - 24 時間表記。未選択は `null`、placeholder で `HH:mm` フォーマットを提示
+ *
+ * Select×2（時・分）に対する利点: 1 フィールドで完結し、`0930` のような連続入力・ペーストで素早く絞り込める。
+ * 注意: 候補に無い任意時刻（例 `09:38`）の確定には別途パース/バリデーションが必要（このデモは候補からの選択のみ）。
+ */
+
+type TimeOption = { value: string; label: string };
+
+// step（分刻み）から HH:mm 候補を自動生成する（24h × (60 / step) 件）
+function createTimeOptions(step: number): TimeOption[] {
+  const minutesPerHour = Math.floor(60 / step);
+
+  return Array.from({ length: 24 }, (_, hour) => hour).flatMap((hour) =>
+    Array.from({ length: minutesPerHour }, (_, index) => {
+      const label = `${String(hour).padStart(2, '0')}:${String(index * step).padStart(2, '0')}`;
+
+      return { value: label, label };
+    }),
+  );
+}
+
+// 入力テキストで候補を絞り込む。`09:30`（そのまま）/ `0930`（数字のみ）の双方でヒットさせる
+function filterTimeOptions(options: TimeOption[], inputText: string): TimeOption[] {
+  if (inputText === '') {
+    return options;
+  }
+  const normalized = inputText.replace(/[^0-9]/g, '');
+
+  return options.filter((option) => {
+    if (option.label.includes(inputText)) {
+      return true;
+    }
+
+    return normalized !== '' && option.label.replace(':', '').includes(normalized);
+  });
+}
+
+type TimeComboboxFieldProps = {
+  step?: number;
+  size?: ComboboxSize;
+  isError?: boolean;
+  isDisabled?: boolean;
+};
+
+function TimeComboboxField({
+  step = 15,
+  size = 'medium',
+  isError = false,
+  isDisabled = false,
+}: TimeComboboxFieldProps) {
+  const [value, setValue] = useState<string | null>(null);
+  const [inputText, setInputText] = useState('');
+  const options = useMemo(() => createTimeOptions(step), [step]);
+  const filtered = useMemo(() => filterTimeOptions(options, inputText), [options, inputText]);
+
+  const handleChange = (next: string | null, meta: ComboboxChangeMeta | null) => {
+    setValue(next);
+    setInputText(meta?.label ?? '');
+  };
+
+  return (
+    <div style={{ width: 200 }}>
+      <Combobox
+        size={size}
+        value={value}
+        onChange={handleChange}
+        inputValue={inputText}
+        onInputChange={setInputText}
+        placeholder="HH:mm"
+        isError={isError}
+        isDisabled={isDisabled}
+        listMaxHeight={240}
+        matchListToTrigger
+      >
+        <Combobox.Input>
+          <Combobox.HelperMessage>選択値: {value ?? '未選択'}</Combobox.HelperMessage>
+        </Combobox.Input>
+        <Combobox.List>
+          {filtered.length === 0 && inputText.length > 0 && <Combobox.Empty />}
+          {filtered.map((opt) => (
+            <Combobox.Item key={opt.value} value={opt.value} label={opt.label} />
+          ))}
+        </Combobox.List>
+      </Combobox>
+    </div>
+  );
+}
+
+export const TimeCombobox: Story = {
+  parameters: {
+    chromatic: { disable: true },
+  },
+  render: () => (
+    <div className="flex flex-col gap-2">
+      <p className="typography-label14bold text-text01">時刻（HH:mm）</p>
+      <TimeComboboxField />
+    </div>
+  ),
+  play: async ({ canvas }) => {
+    const user = userEvent.setup();
+    const input = canvas.getByRole('combobox');
+
+    // 数字のみ（0930）でも HH:mm 候補が絞り込めることを確認
+    await user.click(input);
+    await user.type(input, '0930');
+    const body = within(document.body);
+    const option = await body.findByRole('option', { name: '09:30', hidden: true });
+    await user.click(option);
+
+    // 選択した候補が input に反映されることを確認
+    await expect(input).toHaveValue('09:30');
+  },
+};
+
+export const TimeComboboxSizes: Story = {
+  decorators: [
+    (StoryFn) => (
+      <div style={{ paddingBottom: 280 }}>
+        <StoryFn />
+      </div>
+    ),
+  ],
+  render: () => (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-2">
+        <p className="typography-label14bold text-text01">medium</p>
+        <TimeComboboxField size="medium" />
+      </div>
+      <div className="flex flex-col gap-2">
+        <p className="typography-label14bold text-text01">large</p>
+        <TimeComboboxField size="large" />
+      </div>
+    </div>
+  ),
+};
+
+export const TimeComboboxVariants: Story = {
+  decorators: [
+    (StoryFn) => (
+      <div style={{ paddingBottom: 280 }}>
+        <StoryFn />
+      </div>
+    ),
+  ],
+  render: () => (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-2">
+        <p className="typography-label14bold text-text01">15分刻み（デフォルト）</p>
+        <TimeComboboxField step={15} />
+      </div>
+      <div className="flex flex-col gap-2">
+        <p className="typography-label14bold text-text01">30分刻み</p>
+        <TimeComboboxField step={30} />
+      </div>
+      <div className="flex flex-col gap-2">
+        <p className="typography-label14bold text-text01">エラー状態</p>
+        <TimeComboboxField isError />
+      </div>
+      <div className="flex flex-col gap-2">
+        <p className="typography-label14bold text-text01">無効状態</p>
+        <TimeComboboxField isDisabled />
+      </div>
+    </div>
+  ),
+};
+
+/**
+ * 時刻選択を「時」「分」別々の Combobox×2 で構成するサンプル（実験実装フェーズの検証用）。
+ *
+ * 上の単一 Combobox（HH:mm）に対し、Select×2 と同じ「時・分を独立に選ぶ」操作感を Combobox で再現したもの。
+ * - 時は 00〜23、分は `step`（既定 15 分）刻みの候補を自動生成
+ * - 各フィールドはテキストで絞り込み可能（`9` → `09` 等）
+ * - 24 時間表記。未選択は `null`、placeholder `--` で明示
+ */
+
+// 時の候補（00〜23）
+const splitHourOptions: TimeOption[] = Array.from({ length: 24 }, (_, hour) => {
+  const label = String(hour).padStart(2, '0');
+
+  return { value: label, label };
+});
+
+// 分の候補を step（分刻み）から生成
+function createSplitMinuteOptions(step: number): TimeOption[] {
+  const count = Math.floor(60 / step);
+
+  return Array.from({ length: count }, (_, index) => {
+    const label = String(index * step).padStart(2, '0');
+
+    return { value: label, label };
+  });
+}
+
+// セパレータ「:」のタイポグラフィ・高さを Combobox のサイズに合わせる
+const splitSeparatorClass: Record<ComboboxSize, string> = {
+  medium: 'typography-label14regular h-8',
+  large: 'typography-label16regular h-10',
+};
+
+type TimeComboboxSplitFieldProps = {
+  minuteStep?: number;
+  size?: ComboboxSize;
+  isError?: boolean;
+  isDisabled?: boolean;
+};
+
+function TimeComboboxSplitField({
+  minuteStep = 15,
+  size = 'medium',
+  isError = false,
+  isDisabled = false,
+}: TimeComboboxSplitFieldProps) {
+  const [hour, setHour] = useState<string | null>(null);
+  const [hourInput, setHourInput] = useState('');
+  const [minute, setMinute] = useState<string | null>(null);
+  const [minuteInput, setMinuteInput] = useState('');
+
+  const minuteOptions = useMemo(() => createSplitMinuteOptions(minuteStep), [minuteStep]);
+  const filteredHours = useMemo(() => filterTimeOptions(splitHourOptions, hourInput), [hourInput]);
+  const filteredMinutes = useMemo(() => filterTimeOptions(minuteOptions, minuteInput), [minuteOptions, minuteInput]);
+
+  const fieldWidth = 112;
+
+  const handleHourChange = (next: string | null, meta: ComboboxChangeMeta | null) => {
+    setHour(next);
+    setHourInput(meta?.label ?? '');
+  };
+  const handleMinuteChange = (next: string | null, meta: ComboboxChangeMeta | null) => {
+    setMinute(next);
+    setMinuteInput(meta?.label ?? '');
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <div style={{ width: fieldWidth }}>
+        <Combobox
+          size={size}
+          value={hour}
+          onChange={handleHourChange}
+          inputValue={hourInput}
+          onInputChange={setHourInput}
+          placeholder="--"
+          isError={isError}
+          isDisabled={isDisabled}
+          listMaxHeight={200}
+          matchListToTrigger
+        >
+          <Combobox.Input />
+          <Combobox.List>
+            {filteredHours.length === 0 && hourInput.length > 0 && <Combobox.Empty />}
+            {filteredHours.map((opt) => (
+              <Combobox.Item key={opt.value} value={opt.value} label={opt.label} />
+            ))}
+          </Combobox.List>
+        </Combobox>
+      </div>
+      <span className={`${splitSeparatorClass[size]} flex items-center text-text02`}>:</span>
+      <div style={{ width: fieldWidth }}>
+        <Combobox
+          size={size}
+          value={minute}
+          onChange={handleMinuteChange}
+          inputValue={minuteInput}
+          onInputChange={setMinuteInput}
+          placeholder="--"
+          isError={isError}
+          isDisabled={isDisabled}
+          listMaxHeight={200}
+          matchListToTrigger
+        >
+          <Combobox.Input />
+          <Combobox.List>
+            {filteredMinutes.length === 0 && minuteInput.length > 0 && <Combobox.Empty />}
+            {filteredMinutes.map((opt) => (
+              <Combobox.Item key={opt.value} value={opt.value} label={opt.label} />
+            ))}
+          </Combobox.List>
+        </Combobox>
+      </div>
+    </div>
+  );
+}
+
+export const TimeComboboxSplit: Story = {
+  parameters: {
+    chromatic: { disable: true },
+  },
+  render: () => (
+    <div className="flex flex-col gap-2">
+      <p className="typography-label14bold text-text01">時刻（時・分を別々に選択）</p>
+      <TimeComboboxSplitField />
+    </div>
+  ),
+  play: async ({ canvas }) => {
+    const user = userEvent.setup();
+    const [hourInput, minuteInput] = canvas.getAllByRole('combobox');
+    if (hourInput == null || minuteInput == null) {
+      return;
+    }
+    const body = within(document.body);
+
+    // 時: 「9」で絞り込み、候補 09 を選択
+    await user.click(hourInput);
+    await user.type(hourInput, '9');
+    const hourOption = await body.findByRole('option', { name: '09', hidden: true });
+    await user.click(hourOption);
+    await expect(hourInput).toHaveValue('09');
+
+    // 分: 「30」で絞り込み、候補 30 を選択
+    await user.click(minuteInput);
+    await user.type(minuteInput, '30');
+    const minuteOption = await body.findByRole('option', { name: '30', hidden: true });
+    await user.click(minuteOption);
+    await expect(minuteInput).toHaveValue('30');
+  },
+};
+
+export const TimeComboboxSplitSizes: Story = {
+  decorators: [
+    (StoryFn) => (
+      <div style={{ paddingBottom: 240 }}>
+        <StoryFn />
+      </div>
+    ),
+  ],
+  render: () => (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-2">
+        <p className="typography-label14bold text-text01">medium</p>
+        <TimeComboboxSplitField size="medium" />
+      </div>
+      <div className="flex flex-col gap-2">
+        <p className="typography-label14bold text-text01">large</p>
+        <TimeComboboxSplitField size="large" />
+      </div>
+    </div>
+  ),
+};
+
+export const TimeComboboxSplitVariants: Story = {
+  decorators: [
+    (StoryFn) => (
+      <div style={{ paddingBottom: 240 }}>
+        <StoryFn />
+      </div>
+    ),
+  ],
+  render: () => (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-2">
+        <p className="typography-label14bold text-text01">15分刻み（デフォルト）</p>
+        <TimeComboboxSplitField minuteStep={15} />
+      </div>
+      <div className="flex flex-col gap-2">
+        <p className="typography-label14bold text-text01">30分刻み</p>
+        <TimeComboboxSplitField minuteStep={30} />
+      </div>
+      <div className="flex flex-col gap-2">
+        <p className="typography-label14bold text-text01">エラー状態</p>
+        <TimeComboboxSplitField isError />
+      </div>
+      <div className="flex flex-col gap-2">
+        <p className="typography-label14bold text-text01">無効状態</p>
+        <TimeComboboxSplitField isDisabled />
+      </div>
+    </div>
+  ),
 };

--- a/packages/component-ui/src/select/select.stories.tsx
+++ b/packages/component-ui/src/select/select.stories.tsx
@@ -1,7 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { IconName } from '@zenkigen-inc/component-icons';
 import { iconElements } from '@zenkigen-inc/component-icons';
+import clsx from 'clsx';
 import { useEffect, useRef, useState } from 'react';
+import { expect, userEvent, within } from 'storybook/test';
 
 import { Button } from '../button';
 import { Modal } from '../modal';
@@ -923,3 +925,189 @@ export const DismissOnModalOpen: Story = {
     },
   },
 };
+
+/**
+ * 時刻選択（時・分）を Select×2 で構成するサンプル。
+ *
+ * `docs/time-input-component-design-best-practices.md` の推奨を反映している:
+ * - 分の候補は `step`（既定 15 分）で自動生成し、60 候補を出さない
+ * - 24 時間表記
+ * - 未選択は `null` で表現し、placeholder `--` で明示（`00` で誤魔化さない）
+ * - `:` セパレータは `typography-label14regular`（タイポグラフィトークン）で表示し、`text-[14px]` 等のハードコードをしない
+ */
+
+// 時の候補（00〜23 の 24 個）
+const hourOptions: SelectOption[] = Array.from({ length: 24 }, (_, hour) => {
+  const value = String(hour).padStart(2, '0');
+
+  return { id: `hour-${value}`, value, label: value };
+});
+
+// 分の候補を step（分刻み）から自動生成する
+function createMinuteOptions(step: number): SelectOption[] {
+  const count = Math.floor(60 / step);
+
+  return Array.from({ length: count }, (_, index) => {
+    const value = String(index * step).padStart(2, '0');
+
+    return { id: `minute-${value}`, value, label: value };
+  });
+}
+
+type TimeSelectSize = 'x-small' | 'small' | 'medium' | 'large';
+
+type TimeSelectFieldProps = {
+  size?: TimeSelectSize;
+  minuteStep?: number;
+  isError?: boolean;
+  isDisabled?: boolean;
+  defaultHour?: SelectOption | null;
+  defaultMinute?: SelectOption | null;
+};
+
+// セパレータ「:」のタイポグラフィを Select のサイズに合わせる
+const separatorTypographyClass: Record<TimeSelectSize, string> = {
+  'x-small': 'typography-label12regular',
+  small: 'typography-label14regular',
+  medium: 'typography-label14regular',
+  large: 'typography-label16regular',
+};
+
+function TimeSelectField({
+  size = 'medium',
+  minuteStep = 15,
+  isError = false,
+  isDisabled = false,
+  defaultHour = null,
+  defaultMinute = null,
+}: TimeSelectFieldProps) {
+  const [hour, setHour] = useState<SelectOption | null>(defaultHour);
+  const [minute, setMinute] = useState<SelectOption | null>(defaultMinute);
+  const minuteOptions = createMinuteOptions(minuteStep);
+  const width = size === 'large' ? 88 : 80;
+
+  return (
+    <div className="flex items-center gap-2">
+      <Select
+        size={size}
+        variant="outline"
+        placeholder="--"
+        selectedOption={hour}
+        onChange={(option) => setHour(option)}
+        isError={isError}
+        isDisabled={isDisabled}
+        width={width}
+        optionListMaxHeight={160}
+        matchListToTrigger
+      >
+        {hourOptions.map((option) => (
+          <Select.Option key={option.id} option={option} />
+        ))}
+      </Select>
+      <span className={clsx(separatorTypographyClass[size], 'text-text02')}>:</span>
+      <Select
+        size={size}
+        variant="outline"
+        placeholder="--"
+        selectedOption={minute}
+        onChange={(option) => setMinute(option)}
+        isError={isError}
+        isDisabled={isDisabled}
+        width={width}
+        optionListMaxHeight={160}
+        matchListToTrigger
+      >
+        {minuteOptions.map((option) => (
+          <Select.Option key={option.id} option={option} />
+        ))}
+      </Select>
+    </div>
+  );
+}
+
+export const TimeSelect: Story = {
+  parameters: {
+    chromatic: { disable: true },
+    docs: {
+      description: {
+        story: [
+          'Select を 2 つ並べた時刻選択（時・分）のサンプル。',
+          '',
+          '`docs/time-input-component-design-best-practices.md` の推奨を反映:',
+          '- 分の候補は `step`（既定 15 分）で自動生成し、60 候補を出さない',
+          '- 24 時間表記',
+          '- 未選択は `null` で表現し、placeholder `--` で明示（`00` で誤魔化さない）',
+          '- `isError` / `isDisabled` に対応',
+        ].join('\n'),
+      },
+    },
+  },
+  render: () => (
+    <div className="flex flex-col gap-2">
+      <p className="typography-label14bold text-text01">時刻</p>
+      <TimeSelectField />
+    </div>
+  ),
+  play: async ({ canvas }) => {
+    const user = userEvent.setup();
+    const [hourTrigger] = canvas.getAllByRole('button', { name: '--' });
+    await expect(hourTrigger).toBeDefined();
+    if (hourTrigger == null) {
+      return;
+    }
+
+    // 時の Select を開き、候補から 08 を選択
+    await user.click(hourTrigger);
+    const body = within(document.body);
+    const hourOption = await body.findByRole('button', { name: '08' });
+    await user.click(hourOption);
+
+    // トリガーの表示が選択値に更新されることを確認
+    await expect(canvas.getByRole('button', { name: '08' })).toBeInTheDocument();
+  },
+};
+
+export function TimeSelectVariants() {
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-2">
+        <p className="typography-label14bold text-text01">15分刻み（デフォルト）</p>
+        <TimeSelectField minuteStep={15} />
+      </div>
+      <div className="flex flex-col gap-2">
+        <p className="typography-label14bold text-text01">30分刻み</p>
+        <TimeSelectField minuteStep={30} />
+      </div>
+      <div className="flex flex-col gap-2">
+        <p className="typography-label14bold text-text01">選択済み</p>
+        <TimeSelectField
+          defaultHour={{ id: 'hour-09', value: '09', label: '09' }}
+          defaultMinute={{ id: 'minute-30', value: '30', label: '30' }}
+        />
+      </div>
+      <div className="flex flex-col gap-2">
+        <p className="typography-label14bold text-text01">エラー状態</p>
+        <TimeSelectField isError />
+      </div>
+      <div className="flex flex-col gap-2">
+        <p className="typography-label14bold text-text01">無効状態</p>
+        <TimeSelectField isDisabled />
+      </div>
+    </div>
+  );
+}
+
+export function TimeSelectSizes() {
+  const sizes: TimeSelectSize[] = ['x-small', 'small', 'medium', 'large'];
+
+  return (
+    <div className="flex flex-col gap-6">
+      {sizes.map((size) => (
+        <div key={size} className="flex flex-col gap-2">
+          <p className="typography-label14bold text-text01">{size}</p>
+          <TimeSelectField size={size} />
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要

Storybook 共有用に、時刻選択 UI の実験 Story を追加する。実装本体（Select / Combobox）には変更を加えず、既存コンポーネントを組み合わせて 3 パターンを比較できるようにする。

> [!NOTE]
> このブランチは [#588 (feat/combobox-clear-button-opt-in)](../pull/588) にスタックしている。マージ順序に注意。先に親 PR が main にマージされた後、本 PR の base を main に切り替えてからマージしてほしい。
> （※ #588 の番号は仮。実 PR 番号に合わせて読み替え）

## 追加 Story

| Story | 構成 | 特徴 |
| --- | --- | --- |
| `Select / TimeSelect` 系 | Select × 2（時・分） | 15 / 30 分刻みを `step` で生成。サイズ・状態のバリアントあり |
| `Combobox / TimeCombobox` 系 | Combobox 単一（HH:mm） | テキスト絞り込み対応。`0930` のような数字のみ連続入力でも `09:30` にヒット |
| `Combobox / TimeComboboxSplit` 系 | Combobox × 2（時・分） | Select × 2 と同じ操作感を Combobox で再現 |

いずれも `chromatic: { disable: true }` 指定で VRT は走らせない。`docs/time-input-component-design-best-practices.md` の推奨（step 刻み・24 時間表記・未選択は `null`・placeholder で書式を明示）を反映している。

## 共有したい比較観点

- 単一 Combobox（`TimeCombobox`）と 2 分割（`TimeComboboxSplit` / `TimeSelect`）で、入力スピード・候補数・空打ち時の認知負荷がどう違うか
- Select × 2 と Combobox × 2 の比較（インクリメンタル絞り込みの価値）
- TimeSelect コンポーネントとして正式に切り出すかどうかの判断材料

## Storybook

ローカルで `yarn storybook` を起動し、以下を確認:

- `Inputs / Select` → `TimeSelect` / `TimeSelectVariants` / `TimeSelectSizes`
- `Inputs / Combobox` → `TimeCombobox` / `TimeComboboxSizes` / `TimeComboboxVariants` / `TimeComboboxSplit` / `TimeComboboxSplitSizes` / `TimeComboboxSplitVariants`

## 実行コマンド

```bash
yarn lint
yarn type-check
yarn storybook
```

## チェックリスト

- [x] lint / type-check が通る
- [x] VRT を増やさない（`chromatic: { disable: true }`）
- [x] 実装本体（Select / Combobox）には変更を加えていない