### PR TITLE
ci(chromatic): add v2-main baseline builds and manual full-rebuild dispatch

### DIFF
--- a/.github/workflows/chromatic.yaml
+++ b/.github/workflows/chromatic.yaml
@@ -6,6 +6,9 @@ on:
   push:
     branches:
       - main
+      - v2-main
+  # baseline の再確立用: 手動起動時は TurboSnap を無効化し全ストーリーを撮影する
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -32,6 +35,7 @@ jobs:
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           onlyChanged: true
+          forceRebuild: ${{ github.event_name == 'workflow_dispatch' }}
           # component-config はトークン→生成 CSS 経由で全コンポーネントの見た目に影響するが、
           # import グラフに現れず TurboSnap が検知できないため、変更時は全ストーリーを再撮影する
           externals: packages/component-config/**

--- a/.github/workflows/chromatic.yaml
+++ b/.github/workflows/chromatic.yaml
@@ -32,6 +32,9 @@ jobs:
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           onlyChanged: true
+          # component-config はトークン→生成 CSS 経由で全コンポーネントの見た目に影響するが、
+          # import グラフに現れず TurboSnap が検知できないため、変更時は全ストーリーを再撮影する
+          externals: packages/component-config/**
         env:
           IS_CHROMATIC: 'true'
 


### PR DESCRIPTION
> [!NOTE]
> この PR は #582（Tailwind CSS v4 対応）の前提となる workflow 修正です。#582 は本 PR にスタックしています。

## 概要

Tailwind CSS v4（v2.0）ではデザイントークンの反映経路が CSS-first になり、`component-config` が**ビルド時に生成する CSS**（`@theme` / `@utility`）を通じて全コンポーネントの見た目が決まる。

一方、Chromatic の TurboSnap は **JS モジュールの import グラフ**で影響範囲を判定するため、「component-config の変更 → 生成 CSS → 全コンポーネントの描画変化」という経路を検知できない。このままではトークンや CSS 生成ロジックを変更した PR で視覚差分が撮影されず、**レビューされないまま baseline が古い見た目のコピーで更新され、無関係な後続 PR に差分が漏れ出す**。v4 移行を機にこの盲点を workflow 設定で塞ぐ。

## 変更内容（chromatic.yaml）

### 1. `externals: packages/component-config/**`

TurboSnap に「この glob に合致するファイルの変更は Storybook 全体に影響する」と宣言する [chromaui/action のオプション](https://www.chromatic.com/docs/turbosnap/#specify-external-files-to-trigger-a-full-re-test-when-changed)。合致する変更を含むビルドでは全ストーリーを再スナップショットする。

対象となる主なファイル:

- `style-dictionary/tokens.json` — デザイントークンの原本
- `src/tokens/tokens.ts` — 生成されたトークン定数
- `src/generate-styles.mts` — 配布 CSS（`@theme` / `@utility` / `@source inline`）の生成ロジック

いずれも import グラフに現れずに全コンポーネントの描画へ影響するファイル。

### 2. push トリガーに `v2-main` を追加

```yaml
push:
  branches:
    - main
    - v2-main
```

現状 baseline ブランチは `main` のみで、v2 系 PR（base: `v2-main`）の比較基準となる Chromatic ビルドを v2-main 上に持てない。v2 開発期間中は v2-main も baseline ブランチとして push 時にビルドする。

### 3. `workflow_dispatch` + `forceRebuild`

```yaml
workflow_dispatch:
```

```yaml
forceRebuild: ${{ github.event_name == 'workflow_dispatch' }}
```

baseline を再確立したいときに、手動で「TurboSnap を無効化した全ストーリー撮影ビルド」を起動できるようにする（`gh workflow run chromatic.yaml --ref <branch>`）。式は手動起動時のみ `true` になるため、**PR / push の自動ビルドは従来どおり TurboSnap 有効のまま**（スナップショット消費は増えない）。

## 影響範囲

- CI（Chromatic workflow）のみ。ライブラリのコード・配布物への影響なし
- component-config を変更する PR は全 162 ストーリーを撮影するためスナップショット消費が増えるが、トークン変更の視覚差分を当該 PR で確実にレビューできることを優先

## 検証

- 本ブランチ上で `workflow_dispatch` を実行し、全 162 ストーリーが撮影されることを確認済み（[Build 1966](https://www.chromatic.com/build?appId=639bcc36e4bdc7deb6496ad2&number=1966)）
- `yarn prettier --check .github/workflows/chromatic.yaml` — OK（workflow のみの変更のため build / type-check / test への影響なし）