### PR TITLE
293｜docs: update docs to Tailwind v4 CSS-first premise

### DIFF
--- a/docs/coding-guidelines.md
+++ b/docs/coding-guidelines.md
@@ -203,7 +203,7 @@ const config = {
 
 ### Tailwind CSS
 
-- `@zenkigen-inc/component-config`のプリセットを使用
+- `@zenkigen-inc/component-config`が提供するスタイル（`@import '@zenkigen-inc/component-config/styles'`）を使用
 - `clsx`を使用した動的クラス名生成をサポート
 
 ```typescript

--- a/docs/component/color-specification.md
+++ b/docs/component/color-specification.md
@@ -27,14 +27,13 @@ Tailwind のユーティリティクラス（`text-*` / `bg-*` / `border-*` な�
 
 ## 利用前提
 
-Tailwind のプリセットとして `@zenkigen-inc/component-config` を組み込んだ環境で利用する。
+CSS エントリで `@zenkigen-inc/component-config/styles` を読み込んだ環境で利用する。
 Color を import する必要はない。
 
-```javascript
-// tailwind.config.js
-module.exports = {
-  presets: [require('@zenkigen-inc/component-config')],
-};
+```css
+/* globals.css */
+@import 'tailwindcss';
+@import '@zenkigen-inc/component-config/styles';
 ```
 
 ## 基本的な使用方法

--- a/docs/component/color-specification.md
+++ b/docs/component/color-specification.md
@@ -27,13 +27,13 @@ Tailwind のユーティリティクラス（`text-*` / `bg-*` / `border-*` な�
 
 ## 利用前提
 
-CSS エントリで `@zenkigen-inc/component-config/styles` を読み込んだ環境で利用する。
+テーマ CSS（`@zenkigen-inc/component-config/styles`）が読み込まれている環境で利用する。標準セットアップの `@zenkigen-inc/component-ui/styles` に含まれる。
 Color を import する必要はない。
 
 ```css
 /* globals.css */
 @import 'tailwindcss';
-@import '@zenkigen-inc/component-config/styles';
+@import '@zenkigen-inc/component-ui/styles';
 ```
 
 ## 基本的な使用方法

--- a/docs/component/evaluation-star-specification.md
+++ b/docs/component/evaluation-star-specification.md
@@ -176,7 +176,7 @@ const LargeRating = () => {
 ## スタイルのカスタマイズ
 
 - 色やフォーカスリングは`@zenkigen-inc/component-theme`で提供される`focusVisible`や`fill-*`トークンによって制御される
-- 星の大きさを変更したい場合は、Tailwindプリセット（`@zenkigen-inc/component-config`）に同名ユーティリティを追加するか、カスタムクラスを拡張して再ビルドする
+- 星の大きさを変更したい場合は、`@zenkigen-inc/component-config`のスタイル定義に同名ユーティリティ（`@utility`）を追加するか、カスタムクラスを拡張して再ビルドする
 - 企業ブランドカラーに合わせた評価色へ変更する場合は、`component-theme`内の`fill-yellow-yellow50`や`fill-icon03`に対応するトークン値を調整する
 
 ## 更新履歴

--- a/docs/component/heading-specification.md
+++ b/docs/component/heading-specification.md
@@ -145,7 +145,7 @@ import { Button, Icon } from '@zenkigen-inc/component-ui';
 
 - タイポグラフィやカラーを変更する場合は `@zenkigen-inc/component-theme` の `typography.heading` や `text` トークンを調整する。
 - 行頭/行末に追加余白が必要な場合は、`children` を `<div className="flex-1">` で包み左右にスペースを確保する。
-- `@zenkigen-inc/component-config` のスタイル定義に依存しているため、外部プロジェクトで使用する際は CSS エントリで `@import '@zenkigen-inc/component-config/styles'` を読み込む。
+- `@zenkigen-inc/component-config` のスタイル定義に依存しているため、外部プロジェクトで使用する際は CSS エントリで `@import '@zenkigen-inc/component-ui/styles'`（内部で `@zenkigen-inc/component-config/styles` を読み込む）を記述する。
 
 ## 更新履歴
 

--- a/docs/component/heading-specification.md
+++ b/docs/component/heading-specification.md
@@ -145,7 +145,7 @@ import { Button, Icon } from '@zenkigen-inc/component-ui';
 
 - タイポグラフィやカラーを変更する場合は `@zenkigen-inc/component-theme` の `typography.heading` や `text` トークンを調整する。
 - 行頭/行末に追加余白が必要な場合は、`children` を `<div className="flex-1">` で包み左右にスペースを確保する。
-- Tailwind プリセット（`@zenkigen-inc/component-config`）に依存しているため、外部プロジェクトで使用する際はプリセットを `tailwind.config.js` に登録する。
+- `@zenkigen-inc/component-config` のスタイル定義に依存しているため、外部プロジェクトで使用する際は CSS エントリで `@import '@zenkigen-inc/component-config/styles'` を読み込む。
 
 ## 更新履歴
 

--- a/docs/component/segmented-control-specification.md
+++ b/docs/component/segmented-control-specification.md
@@ -280,7 +280,7 @@ type SegmentedControlContextValue = {
 
 ## スタイルのカスタマイズ
 
-このコンポーネントのスタイルは`@zenkigen-inc/component-config`のTailwind CSSプリセットに依存している。カスタマイズする場合は、プロジェクトのTailwind設定でデザイントークンを調整すること。
+このコンポーネントのスタイルは`@zenkigen-inc/component-config`が提供するスタイル定義（デザイントークン）に依存している。カスタマイズする場合は、デザイントークンを調整すること。
 
 ## 更新履歴
 

--- a/docs/component/toggle-specification.md
+++ b/docs/component/toggle-specification.md
@@ -214,7 +214,7 @@ const ToggleCard = () => {
 - インジケーター色: `iconOnColor`
 - ラベル色: `text01`/`disabled01`
 
-テーマトークンを更新すればトラック色やホバー色を一括で変更できる。サイズの変更は`packages/component-config`のTailwindプリセットを介して行う。
+テーマトークンを更新すればトラック色やホバー色を一括で変更できる。サイズの変更は`packages/component-config`が生成するスタイル定義を介して行う。
 
 ## 更新履歴
 

--- a/docs/component/typography-specification.md
+++ b/docs/component/typography-specification.md
@@ -29,12 +29,12 @@ Heading / Body / Label を通じてサイズ・行高・太さを統一し、UI 
 ## 利用前提
 
 Typography はコンポーネントではなく CSS ユーティリティであるため、import は不要である。
-CSS エントリで `@zenkigen-inc/component-config/styles` を読み込んだ環境で利用する。
+テーマ CSS（`@zenkigen-inc/component-config/styles`）が読み込まれている環境で利用する。標準セットアップの `@zenkigen-inc/component-ui/styles` に含まれる。
 
 ```css
 /* globals.css */
 @import 'tailwindcss';
-@import '@zenkigen-inc/component-config/styles';
+@import '@zenkigen-inc/component-ui/styles';
 ```
 
 ## 基本的な使用方法

--- a/docs/component/typography-specification.md
+++ b/docs/component/typography-specification.md
@@ -29,13 +29,12 @@ Heading / Body / Label を通じてサイズ・行高・太さを統一し、UI 
 ## 利用前提
 
 Typography はコンポーネントではなく CSS ユーティリティであるため、import は不要である。
-`@zenkigen-inc/component-config` の Tailwind プリセットを読み込んだ環境で利用する。
+CSS エントリで `@zenkigen-inc/component-config/styles` を読み込んだ環境で利用する。
 
-```javascript
-// tailwind.config.js
-module.exports = {
-  presets: [require('@zenkigen-inc/component-config')],
-};
+```css
+/* globals.css */
+@import 'tailwindcss';
+@import '@zenkigen-inc/component-config/styles';
 ```
 
 ## 基本的な使用方法

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -101,18 +101,18 @@ component-theme
 
 ### 3. @zenkigen-inc/component-config
 
-このパッケージは、Tailwind CSS の設定を提供します。
+このパッケージは、Tailwind CSS 用のスタイル定義（CSS）を提供します。
 
 **主な特徴**:
 
-- Tailwind CSS のプリセット設定
-- Design Token を Tailwind の設定に変換
+- Design Token を CSS 変数に変換（`@theme` ディレクティブ）
+- タイポグラフィ・z-index 等のカスタムユーティリティ生成（`@utility` ディレクティブ）
 - component-themeパッケージに依存
-- Tailwindプラグインによるタイポグラフィユーティリティクラスの生成
+- 生成した CSS を `exports["./styles"]` として配布
 
 **主要ファイル**:
 
-- tailwind-config.ts: Tailwind CSS の設定
+- generate-styles.mts: 配布用 CSS（`dist/{theme,utilities,index}.css`）の生成スクリプト
 - tokens/tokens.ts: Design Token の定義
 
 ### 4. @zenkigen-inc/component-icons

--- a/docs/theme-system.md
+++ b/docs/theme-system.md
@@ -4,7 +4,7 @@
 
 ## テーマシステム概要
 
-Zenkigen Component のテーマシステムは、`@zenkigen-inc/component-theme` パッケージで定義され、`@zenkigen-inc/component-config` パッケージを通じてTailwind CSSの設定に変換されます。
+Zenkigen Component のテーマシステムは、`@zenkigen-inc/component-theme` パッケージで定義され、`@zenkigen-inc/component-config` パッケージを通じて CSS-first 形式のスタイル（`@theme` / `@utility`）に変換されます。
 
 ## パッケージの役割
 
@@ -21,13 +21,13 @@ Zenkigen Component のテーマシステムは、`@zenkigen-inc/component-theme`
 
 ### @zenkigen-inc/component-config
 
-このパッケージは、`component-theme` で定義された変数をTailwind CSSの設定に変換し、Tailwindプリセットとして提供します。
+このパッケージは、`component-theme` で定義された変数を CSS に変換し、`exports["./styles"]`（`dist/index.css`）として配布します。
 
 主な役割：
 
-- Tailwind CSSのプリセット設定の生成
-- デザイントークンのTailwind CSS設定への変換
-- タイポグラフィユーティリティクラスの生成
+- デザイントークンの CSS 変数への変換（`@theme` ディレクティブ）
+- タイポグラフィ・z-index 等のカスタムユーティリティ生成（`@utility` ディレクティブ）
+- 動的クラス（`fill-*`）の safelist 提供（`@source inline`）
 
 ## テーマの構成
 
@@ -44,11 +44,11 @@ Zenkigen Component のテーマシステムは、`@zenkigen-inc/component-theme`
 
 ### タイポグラフィシステム
 
-タイポグラフィシステムは、フォントサイズ、行の高さ、フォントウェイトなどの組み合わせを定義します。これらは、Tailwindプラグインにより `.typography-*` というユーティリティクラスとして使用できます。
+タイポグラフィシステムは、フォントサイズ、行の高さ、フォントウェイトなどの組み合わせを定義します。これらは `@utility` として生成され、`.typography-*` というユーティリティクラスで使用できます。
 
 例：
 
-- `.typography-heading24bold`
+- `.typography-h2`
 - `.typography-label16regular`
 - `.typography-body14regular`
 
@@ -100,68 +100,24 @@ z-index はコンポーネントの重なり順を制御するために使用し
 
 #### 定義場所
 
-z-index の値は `packages/component-config/src/tailwind-config.ts` で定義されています。
+z-index の値は `packages/component-config/src/generate-styles.mts` で定義され、`@utility z-*` として生成されます。
 
-## Tailwind CSS設定
+## CSS の生成（CSS-first 構成）
 
-### 設定のカスタマイズ
+Tailwind CSS の CSS-first 構成に対応するため、`component-config` はビルド時に `src/generate-styles.mts` を実行し、tokens と `component-theme` の typography から以下の CSS を `dist/` に生成します：
 
-`tailwind-config.ts` では、Tailwind CSSの設定をカスタマイズしています：
+| ファイル             | 内容                                                                                                                                                 |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dist/theme.css`     | `@theme` ディレクティブ。カラー・fontSize・lineHeight・shadow・アニメーションのトークンを CSS 変数として定義                                         |
+| `dist/utilities.css` | `@utility` ディレクティブ。`z-*`・`typography-*`・`field-sizing-content` 等のカスタムユーティリティと、動的クラス用の `@source inline("fill-{...}")` |
+| `dist/index.css`     | エントリファイル（上記 2 つを `@import`）。`exports["./styles"]` で公開                                                                              |
 
-```tsx
-export const tailwindConfig = {
-  theme: {
-    extend: {
-      fontFamily: {
-        sans: "Arial, 'Noto Sans JP', sans-serif",
-      },
-      colors: {
-        user: tokens.user,
-        ...text,
-        ...link,
-        ...border,
-        ...background,
-        ...icon,
-        // ...その他の色定義
-      },
-      fontSize: tokens.fontSize,
-      lineHeight: tokens.lineHeights,
-      borderRadius: {
-        button: '.25rem',
-      },
-      boxShadow: {
-        modalShadow: tokens.shadow.modalShadow,
-        floatingShadow: tokens.shadow.floatingShadow,
-        layoutShadow: tokens.shadow.layoutShadow,
-      },
-      // ...その他の設定
-    },
-  },
-  plugins: [
-    // タイポグラフィユーティリティクラスを生成するプラグイン
-    plugin(({ addComponents }) => {
-      addComponents(
-        Object.entries(typography).reduce(
-          (acc, [, innerObj]) => (
-            Object.entries(innerObj).forEach(
-              ([innerKey, value]) => (acc[`.typography-${innerKey}`] = { [`@apply ${value}`]: {} }),
-            ),
-            acc
-          ),
-          {} as Record<string, Record<string, {}>>,
-        ),
-      );
-    }),
-  ],
-};
-```
+### タイポグラフィユーティリティ
 
-### タイポグラフィプラグイン
-
-タイポグラフィユーティリティクラスは、Tailwindプラグインを使用して生成されます。これにより、例えば以下のようなクラスが使用可能になります：
+タイポグラフィユーティリティクラスは `@utility typography-* { @apply ... }` として生成されます。これにより、例えば以下のようなクラスが使用可能になります：
 
 ```html
-<h1 class="typography-heading24bold">タイトル</h1>
+<h2 class="typography-h2">タイトル</h2>
 <p class="typography-body14regular">テキスト</p>
 ```
 
@@ -178,8 +134,8 @@ yarn update-tokens # トークンの更新コマンド
 このコマンドは以下のプロセスを実行します：
 
 1. `token-transformer` を使用してトークンを変換
-2. Style Dictionaryを使用してJavaScriptオブジェクトを生成
-3. 生成されたオブジェクトをTailwind CSS設定で使用
+2. Style Dictionaryを使用してJavaScriptオブジェクト（`src/tokens/tokens.ts`）を生成
+3. ビルド時に `generate-styles.mts` が生成されたオブジェクトから配布用 CSS（`@theme` / `@utility`）を生成
 
 ## コンポーネントでのテーマの利用
 
@@ -200,20 +156,15 @@ const baseClasses = clsx(
 
 ## Tailwind CSSの組み込み方法
 
-プロジェクトでZenkigen Componentを使用するには、以下のようにTailwind CSSの設定を行います：
+プロジェクトでZenkigen Componentを使用するには、CSS エントリ（例: `globals.css`）で以下のように読み込みます：
 
-```js
-// tailwind.config.js
-module.exports = {
-  content: [
-    // 既存の設定...
-    './node_modules/@zenkigen-inc/**/*.{js,ts,tsx}',
-  ],
-  presets: [
-    // 既存のプリセット...
-    require('@zenkigen-inc/component-config'),
-  ],
-};
+```css
+@import 'tailwindcss';
+@import '@zenkigen-inc/component-config/styles';
+
+/* zenkigen-component の動的クラスを検出（パスは CSS エントリから node_modules への相対パス） */
+@source '../../node_modules/@zenkigen-inc/component-theme/dist/**/*.mjs';
+@source '../../node_modules/@zenkigen-inc/component-ui/dist/**/*.mjs';
 ```
 
-これにより、Zenkigen Componentで使用されているTailwindのユーティリティクラスが、プロジェクトのCSSビルドに含まれるようになります。
+これにより、Zenkigen Componentで使用されているTailwindのユーティリティクラスが、プロジェクトのCSSビルドに含まれるようになります。v1.x（Tailwind v3 / JS preset）からの移行は [v1 → v2 移行ガイド](./migration-v1-to-v2.md) を参照してください。

--- a/docs/theme-system.md
+++ b/docs/theme-system.md
@@ -160,11 +160,7 @@ const baseClasses = clsx(
 
 ```css
 @import 'tailwindcss';
-@import '@zenkigen-inc/component-config/styles';
-
-/* zenkigen-component の動的クラスを検出（パスは CSS エントリから node_modules への相対パス） */
-@source '../../node_modules/@zenkigen-inc/component-theme/dist/**/*.mjs';
-@source '../../node_modules/@zenkigen-inc/component-ui/dist/**/*.mjs';
+@import '@zenkigen-inc/component-ui/styles';
 ```
 
-これにより、Zenkigen Componentで使用されているTailwindのユーティリティクラスが、プロジェクトのCSSビルドに含まれるようになります。v1.x（Tailwind v3 / JS preset）からの移行は [v1 → v2 移行ガイド](./migration-v1-to-v2.md) を参照してください。
+`@zenkigen-inc/component-ui/styles` は、デザイントークンの読み込み（`@zenkigen-inc/component-config/styles`）と、コンポーネントが実行時に参照する動的クラスの検出（`@source`）をまとめて提供します。利用側で `@source` や `node_modules` への相対パスを記述する必要はありません。これにより、Zenkigen Componentで使用されているTailwindのユーティリティクラスが、プロジェクトのCSSビルドに含まれるようになります。v1.x（Tailwind v3 / JS preset）からの移行は [v1 → v2 移行ガイド](./migration-v1-to-v2.md) を参照してください。


### PR DESCRIPTION
> [!NOTE]
>
> - Tailwind CSS v4 対応（#582）に伴うドキュメント更新を、実装レビューから分離した独立 PR
> - 記述は #582 の実装（`generate-styles.mts`）が前提のため、一時的にドキュメントがコードへ先行する（v2-main は開発ブランチで、rc 前に #582 が合流するため実害なし）

## 概要

リポジトリ内の仕組み解説ドキュメント 9 ファイルを、v3（JS preset）前提から v4（CSS-first）前提に書き換える。

なお、バージョン要件（v4 必須等）の記述は README・移行ガイド（#594）・versioning-policy に**一元化**する方針とし、これらの仕組み解説ドキュメントには書かない（将来のメジャー対応時に修正箇所を限定するため）。

## 変更内容

| ファイル | 内容 |
|---|---|
| `docs/theme-system.md` | JS preset・`tailwind-config.ts`・Tailwind プラグインの解説を、CSS 生成（`generate-styles.mts` → `@theme` / `@utility` → `exports["./styles"]`）の解説に全面書き換え。組み込み方法も v4 形式に。存在しないクラス例 `typography-heading24bold` → `typography-h2` に修正 |
| `docs/project-structure.md` | component-config の役割・主要ファイルを v4 の実態に更新 |
| `docs/coding-guidelines.md` | 「プリセットを使用」→ styles import に |
| `docs/component/color-specification.md` / `typography-specification.md` | 「利用前提」の preset 設定例 → CSS `@import` 例に |
| `docs/component/{heading,segmented-control,toggle,evaluation-star}-specification.md` | スタイルカスタマイズ節の「Tailwind プリセット」言及を v4 の実態に |

## 影響範囲

- ドキュメントのみ。コード・配布物への影響なし

## 実行したコマンド

- `yarn prettier --check`（変更ファイル）— OK