### PR TITLE
fix(button): InternalButton を forwardRef 化し React 18 で DatePicker のアンカー解決が壊れる不具合を修正

### DIFF
--- a/packages/component-ui/src/button/button.test.tsx
+++ b/packages/component-ui/src/button/button.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
-import { Button } from './button';
+import { Button, InternalButton } from './button';
 
 describe('Button', () => {
   it('クリック時にonClickが呼ばれること', () => {
@@ -93,5 +93,21 @@ describe('Button', () => {
     (document.activeElement as HTMLElement)?.blur();
     await user.tab();
     expect(screen.getByRole('button', { name: 'フォーカスボタン' })).toHaveFocus();
+  });
+});
+
+describe('InternalButton', () => {
+  it('ref が host の button 要素に到達すること', () => {
+    const ref = React.createRef<HTMLButtonElement>();
+    render(<InternalButton ref={ref}>refボタン</InternalButton>);
+    expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+    expect(ref.current).toBe(screen.getByRole('button', { name: 'refボタン' }));
+  });
+
+  // React 18 では素の関数コンポーネントに渡した ref は破棄され、PopoverTrigger のアンカー解決が
+  // 壊れて DatePicker のカレンダーが (0,0) に描画される。React 19 は ref-as-prop で偶然動くため
+  // 上の描画テストだけでは退行を検知できない。forwardRef であること自体を退行防止として固定する。
+  it('forwardRef コンポーネントであること（React 18 で ref が破棄されないための退行防止）', () => {
+    expect((InternalButton as { $$typeof?: symbol }).$$typeof).toBe(Symbol.for('react.forward_ref'));
   });
 });

--- a/packages/component-ui/src/button/button.tsx
+++ b/packages/component-ui/src/button/button.tsx
@@ -1,6 +1,7 @@
 import { buttonColors, focusVisible } from '@zenkigen-inc/component-theme';
 import { clsx } from 'clsx';
-import type { ComponentPropsWithoutRef, CSSProperties, ElementType, PropsWithChildren, ReactNode } from 'react';
+import type { ComponentPropsWithoutRef, CSSProperties, ElementType, PropsWithChildren, ReactNode, Ref } from 'react';
+import { forwardRef } from 'react';
 
 type Size = 'small' | 'medium' | 'large' | 'x-large';
 type Variant = 'fill' | 'fillDanger' | 'outline' | 'text';
@@ -53,7 +54,7 @@ type InternalProps<T extends ElementAs> = BaseProps<T> & {
 };
 
 // 共通のButton実装
-const createButton = <T extends ElementAs = 'button'>(props: InternalProps<T>) => {
+const createButton = <T extends ElementAs = 'button'>(props: InternalProps<T>, ref?: Ref<HTMLButtonElement>) => {
   const {
     size = 'medium',
     variant = 'fill',
@@ -97,7 +98,7 @@ const createButton = <T extends ElementAs = 'button'>(props: InternalProps<T>) =
   const Component = elementAs ?? 'button';
 
   return (
-    <Component className={baseClasses} style={{ width, borderRadius }} disabled={isDisabled} {...restProps}>
+    <Component ref={ref} className={baseClasses} style={{ width, borderRadius }} disabled={isDisabled} {...restProps}>
       {before}
       {children}
       {after}
@@ -111,6 +112,10 @@ export const Button = <T extends ElementAs = 'button'>(props: PublicProps<T>) =>
 };
 
 // 内部実装用のButtonコンポーネント（outlineDanger variantを含む）
-export const InternalButton = <T extends ElementAs = 'button'>(props: InternalProps<T>) => {
-  return createButton(props);
-};
+// PopoverTrigger 等が cloneElement で注入する ref を host button まで届けるため forwardRef でラップする
+export const InternalButton = forwardRef<HTMLButtonElement, InternalProps<'button'>>(
+  function InternalButton(props, ref) {
+    return createButton(props, ref);
+  },
+);
+InternalButton.displayName = 'InternalButton';


### PR DESCRIPTION
## 概要

React 18 環境で `DatePicker` のカレンダーが画面左上 (0,0) に描画される不具合を修正します。あわせて、開発者コンソールに `Warning: Function components cannot be given refs. Attempts to access this ref will fail.` の警告が出ていました。

原因は、内部コンポーネント `InternalButton` が `forwardRef` でラップされていない素の関数コンポーネントだったことです。

## 原因

`DatePicker` はトリガーボタンとして `Popover.Trigger` の子に `InternalButton` を置いています。`PopoverTrigger` は `cloneElement` で子に `ref` を注入し、その `ref` コールバック（`handleTriggerRef`）で floating-ui のアンカー DOM（`floating.refs.setReference(node)`）を取得しています。

- **React 18**: 関数コンポーネントに渡した `ref` は破棄される（上記の警告が出る）ため、`handleTriggerRef` に host の `<button>` が渡らず、アンカーが `null` のまま。結果として floating-ui が配置基準を失い、カレンダーが `(0,0)` に描画される。
- **React 19**: `ref` が通常の prop として扱われる（ref-as-prop）ため、素の関数コンポーネントでも `...restProps` 経由で `ref` が host 要素へ渡り「偶然」動いていた。

`peerDependencies` は `react: "^18 || ^19"` を宣言しており React 18 サポートを謳っているため、ライブラリ側のバグとして修正します。

## 修正内容

`InternalButton` を `forwardRef` でラップし、受け取った `ref` を共通実装 `createButton` 経由で host の `<button>` 要素へ転送します。既に `forwardRef` 済みの `TextInput` / `List` 等の兄弟実装のスタイルに揃えています。

対象: `packages/component-ui/src/button/button.tsx`

- `createButton` に第2引数 `ref?: Ref<HTMLButtonElement>` を追加し、`<Component ref={ref} ... />` へ転送。
- `InternalButton` を `forwardRef<HTMLButtonElement, InternalProps<'button'>>` でラップし、`displayName` を付与。
- 公開 API の `Button` は変更なし（polymorphic な `elementAs` 型を維持するため最小差分）。

## 検証

`yarn build:all` の後、リポジトリ既定の品質ゲートを実行し全て通過しています。

- `yarn type-check`: パス
- `yarn test:ci`: 28 files / 654 passed, 2 skipped
- `yarn lint`（eslint + prettier --check）: パス

`packages/component-ui/src/button/button.test.tsx` にリグレッションテストを2件追加しました。

- `ref` が host の `<button>` 要素へ到達すること（`toBeInstanceOf(HTMLButtonElement)`。兄弟の ref 転送テストと同スタイル）。
- `InternalButton` が `forwardRef` コンポーネントであること。テスト環境が React 19 のため描画挙動だけでは退行を検知できない（React 19 は ref-as-prop で偶然動く）ため、`forwardRef` であること自体を退行防止として固定しています。修正前のコードに戻すとこのテストが失敗することを確認済みです。

## 影響

- **React 18 利用者**: バグ修正（カレンダーが正しくアンカー基準に配置され、警告も消える）。
- **React 19 利用者（company-web 等）**: 挙動変化なし。これまで ref-as-prop で host 要素に届いていた `ref` が、`forwardRef` 経由で届くようになるだけです。公開 API `Button` の型・シグネチャは不変です。

## 関連

- zenkigen/ilink#1617（消費側の実例。ilink-frontend は React 18.3.1）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
