### PR TITLE
ci(chromatic): add manual full-rebuild dispatch to re-establish stale VRT baselines

### DIFF
--- a/.github/workflows/chromatic.yaml
+++ b/.github/workflows/chromatic.yaml
@@ -6,6 +6,8 @@ on:
   push:
     branches:
       - main
+  # baseline の再確立用: 手動起動時は TurboSnap を無効化し全ストーリーを撮影する
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -32,6 +34,10 @@ jobs:
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           onlyChanged: true
+          forceRebuild: ${{ github.event_name == 'workflow_dispatch' }}
+          # component-config はトークン→生成 CSS 経由で全コンポーネントの見た目に影響するが、
+          # import グラフに現れず TurboSnap が検知できないため、変更時は全ストーリーを再撮影する
+          externals: packages/component-config/**
         env:
           IS_CHROMATIC: 'true'
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@
 - [コンポーネント実装パターン](./component-patterns.md) - コンポーネントの設計パターンと実装方針
 - [テーマシステム](./theme-system.md) - テーマシステムとTailwind CSS設定
 - [Storybook ガイドライン](./storybook-guidelines.md) - Story の作成・構成に関する規約
+- [ビジュアルリグレッションテスト](./visual-regression-testing.md) - Chromatic による VRT の仕組みと運用（TurboSnap・baseline・手動全撮影）
 - [リリース手順](./release-process.md) - npm publish の手順（version bump・タグ・CI publish・dist-tag）
 - [バージョン運用方針](./versioning-policy.md) - メジャーバージョンのライフサイクル・ブランチ戦略・dist-tag 体制
 

--- a/docs/visual-regression-testing.md
+++ b/docs/visual-regression-testing.md
@@ -1,0 +1,85 @@
+# ビジュアルリグレッションテスト（Chromatic）
+
+Storybook の全ストーリーを [Chromatic](https://www.chromatic.com/) でスナップショット撮影し、UI の意図しない見た目の変化（visual regression）を PR 単位で検出する仕組みと運用をまとめる。
+
+> Story 作成時の規約（Chromatic 差分を最小化する Story 分割方針）は [Storybook ガイドライン](./storybook-guidelines.md) を参照。
+
+## 目次
+
+- [概要](#概要)
+- [CI での実行タイミング](#ci-での実行タイミング)
+- [TurboSnap による差分撮影](#turbosnap-による差分撮影)
+  - [import グラフで検知できない変更 — externals](#import-グラフで検知できない変更--externals)
+- [baseline の仕組み](#baseline-の仕組み)
+- [手動トリガーによる全ストーリー撮影（baseline 再確立）](#手動トリガーによる全ストーリー撮影baseline-再確立)
+  - [いつ使うか](#いつ使うか)
+  - [手順](#手順)
+  - [補足](#補足)
+
+## 概要
+
+- workflow: [`.github/workflows/chromatic.yaml`](../.github/workflows/chromatic.yaml)
+- ビルド一覧: <https://www.chromatic.com/builds?appId=639bcc36e4bdc7deb6496ad2>
+- テスト種別: **Visual**（スナップショット比較）と **Accessibility**（axe による a11y リグレッション検出）
+
+## CI での実行タイミング
+
+| トリガー                                                             | 実行内容                                                                                                       |
+| -------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `pull_request`（opened / reopened / synchronize / ready_for_review） | TurboSnap による差分撮影。draft PR と `renovate` / `dependencies` ラベル付き PR はスキップ                     |
+| `push`（main）                                                       | baseline ブランチのビルド。TurboSnap 有効                                                                      |
+| `workflow_dispatch`                                                  | 手動起動。TurboSnap を無効化した全ストーリー撮影（[後述](#手動トリガーによる全ストーリー撮影baseline-再確立)） |
+
+PR には「Chromatic results」コメントが自動投稿され、buildUrl・撮影数・差分数を確認できる。
+
+## TurboSnap による差分撮影
+
+[TurboSnap](https://www.chromatic.com/docs/turbosnap/)（`onlyChanged: true`）は、変更ファイルから JS モジュールの import グラフを辿って影響を受ける story ファイルを特定し、該当ストーリーだけを再撮影する仕組み。影響外のストーリーは直前ビルドのスナップショットがコピーされ、スナップショット消費を抑える。
+
+### import グラフで検知できない変更 — externals
+
+`packages/component-config` はデザイントークンからビルド時に CSS を生成する。この経路（トークン → 生成 CSS → 全コンポーネントの見た目）は import グラフに現れないため、TurboSnap では検知できない。
+
+このため workflow で以下を宣言している（[chromaui/action の externals オプション](https://www.chromatic.com/docs/turbosnap/#specify-external-files-to-trigger-a-full-re-test-when-changed)）:
+
+```yaml
+externals: packages/component-config/**
+```
+
+この glob に合致するファイルを変更した PR では全ストーリーが再撮影される。対象の代表例:
+
+- `style-dictionary/tokens.json` — デザイントークンの原本
+- `src/tokens/tokens.ts` — 生成されたトークン定数
+
+## baseline の仕組み
+
+各ストーリーの差分は **baseline**（最後に accept されたスナップショット）との比較で判定される。
+
+- 差分を accept すると、そのスナップショットが以降のビルドの baseline になる
+- 変更が無い（またはコピーされた）ストーリーの baseline は古いビルドのまま引き継がれる
+- マージ後の main のビルドは merge commit の両親から baseline を引き継ぐ。**PR 上で accept した baseline はマージ後の main に引き継がれる**
+
+## 手動トリガーによる全ストーリー撮影（baseline 再確立）
+
+### いつ使うか
+
+- トークン変更などの見た目への影響が baseline に反映されないまま残り、無関係な後続 PR に古い差分が噴出したとき
+- baseline の状態が信用できなくなり、現行コードの見た目で作り直したいとき
+
+### 手順
+
+```bash
+gh workflow run chromatic.yaml --ref main
+```
+
+（GitHub の Actions タブ → Chromatic → Run workflow からも起動できる）
+
+1. `workflow_dispatch` 起動時は `forceRebuild: true` が渡り、TurboSnap を無効化して全ストーリーを撮影する
+2. ビルド完了後、Chromatic のビルドページで差分をレビューして accept する
+3. accept された内容が新しい baseline になる
+
+### 補足
+
+- PR ブランチに対しても `--ref <ブランチ名>` で実行できる（そのブランチの workflow ファイルに `workflow_dispatch` トリガーが含まれていること）。merge commit 方式でマージすれば、PR 上で accept した baseline はマージ後の main に引き継がれる
+- `workflow_dispatch` のビルドでは PR の「Chromatic results」コメントは更新されない（コメント投稿ステップが PR 番号を前提としているため）。必要なら手動でコメントを編集する
+- PR / push の自動ビルドは従来どおり TurboSnap 有効のままで、スナップショット消費は増えない


### PR DESCRIPTION
> [!NOTE]
> - #601 の Chromatic で無関係な差分（Modal / Popup / Popover、18 件）が噴出した問題への対応です。**#601 が本 PR にスタックしているため、先に本 PR を main へマージしてください**（マージ後、#601 の base は自動的に main に付け替わります）。
> - #593（v2-main 向け）と同内容から `v2-main` の push トリガー追加のみを除いた移植で、将来の v2-main → main マージ時に衝突しません。
> - baseline の再確立は本ブランチ上の `workflow_dispatch` 実行（[Build 1982](https://www.chromatic.com/build?appId=639bcc36e4bdc7deb6496ad2&number=1982)、全 324 snapshots）で実施・accept 済み。merge commit でマージされれば main に引き継がれます。

## 概要

VRT（Chromatic）の baseline に反映されないまま残っていたトークン変更の差分が、無関係な後続 PR に噴出する問題が #601 で顕在化した。baseline を現行の見た目で作り直せるように、**手動トリガーで全ストーリーを撮り直す手段**を workflow に追加する。

## 問題

- Blue50 トークンの変更（#0077D9 への変更 → #177EE5 への復元、40b49dd6）が main にマージされたが、TurboSnap は `packages/component-config` 配下の変更を import グラフで検知できないため、全ストーリーの再撮影が行われなかった
- baseline は旧色のスナップショットのコピーのまま引き継がれ続けた（例: `Modal/Base` の baseline は build 1692 のまま）
- #601（TimePicker 追加）で select.tsx の変更により Modal / Popup / Popover のストーリーが久しぶりに実撮影され、Blue50 変更由来の残留差分 18 件が「TimePicker と無関係な差分」として噴出した

現状の workflow には TurboSnap を無効化して全ストーリーを撮影する手段がなく、baseline を意図的に再確立できない。

## 修正内容

### `workflow_dispatch` + `forceRebuild` — 手動の全ストーリー撮影ビルド

```yaml
forceRebuild: ${{ github.event_name == 'workflow_dispatch' }}
```

`gh workflow run chromatic.yaml --ref main` で「TurboSnap を無効化した全ストーリー撮影ビルド」を手動起動できるようにする。撮影された差分を accept すれば baseline が現行の見た目で再確立され、残留差分は解消される。式は手動起動時のみ `true` になるため、**PR / push の自動ビルドは従来どおり TurboSnap 有効のまま**（スナップショット消費は増えない）。

### `externals: packages/component-config/**` — 同種の残留差分の再発防止

TurboSnap に「この glob に合致するファイルの変更は Storybook 全体に影響する」と宣言する [chromaui/action のオプション](https://www.chromatic.com/docs/turbosnap/#specify-external-files-to-trigger-a-full-re-test-when-changed)。今後トークンや CSS 生成ロジックを変更する PR では全ストーリーが再撮影されるため、今回のような baseline の取りこぼしが発生しなくなる。

### ドキュメント追加: `docs/visual-regression-testing.md`

Chromatic による VRT の仕組みと運用をまとめたドキュメントを新規追加（これまで CI/VRT の運用ドキュメントが存在しなかった）。CI での実行タイミング・TurboSnap と externals・baseline の仕組み・本 PR で追加した手動トリガー全撮影の手順を記載。`docs/README.md` の索引にも追加。

## baseline 再確立の実施状況（実施済み）

1. ~~`gh workflow run chromatic.yaml` で全ストーリー撮影ビルドを実行~~ → 本ブランチ上で実施済み（[Build 1982](https://www.chromatic.com/build?appId=639bcc36e4bdc7deb6496ad2&number=1982)、324 snapshots）
2. ~~現行トークン（Blue50 = #177EE5）で撮影された差分をレビューし accept~~ → 36 件 accept 済み
3. ~~#601 の Chromatic を再実行~~ → #601 を本 PR にスタックしたことで解消済み（[Build 1985](https://www.chromatic.com/build?appId=639bcc36e4bdc7deb6496ad2&number=1985): 残る差分は TimePicker の new stories 8 件のみ）

accept 済み baseline は、本 PR が merge commit で main に入ることで main に引き継がれる。

## 影響範囲

- CI（Chromatic workflow）のみ。ライブラリのコード・配布物への影響なし
- component-config を変更する PR は全ストーリーを撮影するためスナップショット消費が増えるが、トークン変更の視覚差分を当該 PR で確実にレビューできることを優先

## テスト手順

- [ ] マージ後、`gh workflow run chromatic.yaml --ref main` を実行し全ストーリーが撮影されることを確認
- [ ] main の baseline 再確立後、#601 の Chromatic 再実行で無関係な差分が消えることを確認

## 実行したコマンド

- `yarn prettier --check .github/workflows/chromatic.yaml` — OK（workflow のみの変更のため build / type-check / test への影響なし）