### PR TITLE
328｜feat(Icon): Add stroke-icon pipeline with fill-* CSS variable bridge

### DIFF
--- a/packages/component-config/src/tailwind-config.ts
+++ b/packages/component-config/src/tailwind-config.ts
@@ -1,7 +1,14 @@
 import { typography } from '@zenkigen-inc/component-theme';
+import flattenColorPaletteModule from 'tailwindcss/lib/util/flattenColorPalette';
+import toColorValueModule from 'tailwindcss/lib/util/toColorValue';
 import plugin from 'tailwindcss/plugin';
 
 import { tokens } from './tokens/tokens';
+
+// tailwindcss/lib/* は CJS。読み込まれ方（CJS require / ESM import）で default の解決が変わるため両対応する
+const interopDefault = <T>(module: T): T => (module as { default?: T }).default ?? module;
+const flattenColorPalette = interopDefault(flattenColorPaletteModule);
+const toColorValue = interopDefault(toColorValueModule);
 
 const {
   tokens: {
@@ -233,6 +240,13 @@ export const tailwindConfig = {
     'text-supportError',
     // fill-* (Icon の color / accentColor で任意の ColorToken を指定可能にするため)
     { pattern: /^fill-/ },
+    // stroke 系アイコン（lucide 由来）の着色ブリッジとサイズ別 stroke-width 上書き
+    'zen-stroke-icon',
+    '[&_svg]:[stroke-width:2.5]',
+    '[&_svg]:[stroke-width:2.25]',
+    '[&_svg]:[stroke-width:2]',
+    '[&_svg]:[stroke-width:1.75]',
+    '[&_svg]:[stroke-width:1.5]',
     // userColors (Avatar用)
     'bg-user-red',
     'bg-user-pink',
@@ -245,8 +259,35 @@ export const tailwindConfig = {
     'bg-user-yellow',
     'bg-user-orange',
   ],
+  // fill-* は下の plugin で再定義する（CSS 変数ブリッジ）。core 実装は二重定義を避けるため無効化する
+  corePlugins: {
+    fill: false,
+  },
   plugins: [
-    plugin(({ addUtilities, addComponents }) => {
+    plugin(({ addUtilities, addComponents, matchUtilities, theme }) => {
+      // CSS 変数ブリッジ: core の fill plugin と同一シグネチャで fill-* を再定義し、
+      // fill に加えて --zen-icon-stroke を併出力する。CSS 変数は DOM を継承するため、
+      // fill-* がどの要素に付いていても stroke 系アイコン（lucide 由来）に同じ色が届く
+      matchUtilities(
+        {
+          fill: (value) => ({
+            fill: toColorValue(value),
+            '--zen-icon-stroke': toColorValue(value),
+          }),
+        },
+        { values: flattenColorPalette(theme('fill')), type: ['color', 'any'] },
+      );
+      addUtilities({
+        '.zen-stroke-icon': {
+          stroke: 'var(--zen-icon-stroke, currentColor)',
+          // accent path は自身のスコープで変数を解決させる（fill-* が path 上に置くローカル値を拾う）。
+          // fill: none は accentColor の fill-* クラスによる塗り事故を specificity (0,2,0) で防ぐ
+          '& .zen-stroke-accent': {
+            fill: 'none',
+            stroke: 'var(--zen-icon-stroke, currentColor)',
+          },
+        },
+      });
       addUtilities({
         '.field-sizing-content': {
           fieldSizing: 'content',

--- a/packages/component-config/src/tailwind-config.ts
+++ b/packages/component-config/src/tailwind-config.ts
@@ -243,10 +243,10 @@ export const tailwindConfig = {
     // stroke 系アイコン（lucide 由来）の着色ブリッジとサイズ別 stroke-width 上書き
     'zen-stroke-icon',
     '[&_svg]:[stroke-width:2.5]',
-    '[&_svg]:[stroke-width:2.25]',
+    '[&_svg]:[stroke-width:2.35]',
     '[&_svg]:[stroke-width:2]',
-    '[&_svg]:[stroke-width:1.75]',
-    '[&_svg]:[stroke-width:1.5]',
+    '[&_svg]:[stroke-width:1.65]',
+    '[&_svg]:[stroke-width:1.4]',
     // userColors (Avatar用)
     'bg-user-red',
     'bg-user-pink',

--- a/packages/component-config/src/types/tailwindcss-internals.d.ts
+++ b/packages/component-config/src/types/tailwindcss-internals.d.ts
@@ -1,0 +1,11 @@
+// tailwindcss v3 の内部ユーティリティには型定義が無いため、ここで宣言する。
+// core の `fill` plugin と同一シグネチャで fill-* を再定義するために使用する。
+declare module 'tailwindcss/lib/util/flattenColorPalette' {
+  const flattenColorPalette: (colors: unknown) => Record<string, string>;
+  export default flattenColorPalette;
+}
+
+declare module 'tailwindcss/lib/util/toColorValue' {
+  const toColorValue: (value: unknown) => string;
+  export default toColorValue;
+}

--- a/packages/component-icons/codegen.cjs
+++ b/packages/component-icons/codegen.cjs
@@ -56,8 +56,10 @@ async function processLucideSvgFile(file) {
   $('[data-name]').removeAttr('data-name');
   $('svg[id]').removeAttr('id');
   $('svg').removeAttr('class');
-  $('[width]').removeAttr('width');
-  $('[height]').removeAttr('height');
+  // width / height の除去は root の svg に限定する。
+  // 全要素から除去すると <rect> の寸法（width / height 属性）まで消えて図形が描画されなくなる
+  $('svg').removeAttr('width');
+  $('svg').removeAttr('height');
 
   // Handle accent class specially
   $('[class="accent"]').attr('className', '{accentClassName}').removeAttr('class');

--- a/packages/component-icons/codegen.cjs
+++ b/packages/component-icons/codegen.cjs
@@ -37,15 +37,58 @@ async function processSvgFile(file) {
     .replaceAll(/\bclass=/g, 'className=')
     .replaceAll(/(?<!aria)[-]([a-z])/g, (_, x) => x.toUpperCase());
 
-  return { key, value };
+  return { key, value, isLucide: false };
 }
 
-function generateIconFile(key, value) {
+// lucide 由来（stroke 系）: 描画に必須の fill="none" / stroke / stroke-width / stroke-linecap /
+// stroke-linejoin / viewBox を保持したまま変換する
+async function processLucideSvgFile(file) {
+  const content = fs.readFileSync(file).toString('utf8');
+  const $ = cheerio.load(content, {
+    decodeEntities: false,
+  });
+
+  const key = path.basename(file, '.svg');
+
+  $('style,title,defs').remove();
+  $('[id]:not(symbol)').removeAttr('id');
+  $('[style]:not(svg)').removeAttr('style');
+  $('[data-name]').removeAttr('data-name');
+  $('svg[id]').removeAttr('id');
+  $('svg').removeAttr('class');
+  $('[width]').removeAttr('width');
+  $('[height]').removeAttr('height');
+
+  // Handle accent class specially
+  $('[class="accent"]').attr('className', '{accentClassName}').removeAttr('class');
+
+  // Create a dummy element to safely escape the text
+  const escapedKey = $('<div>').text(key).html();
+  $('svg').attr('role', 'img').attr('aria-label', escapedKey);
+
+  // class 値にハイフンを含めると camelCase 変換 regex が値ごと変換してしまうため、
+  // zen-stroke-icon / zen-stroke-accent は変換チェーンの後に文字列注入する
+  const value = $.xml('svg')
+    .replaceAll('"{', '{')
+    .replaceAll('}"', '}')
+    .replaceAll(/\bclass=/g, 'className=')
+    .replaceAll(/(?<!aria)[-]([a-z])/g, (_, x) => x.toUpperCase())
+    .replace('<svg ', '<svg className="zen-stroke-icon" ')
+    .replaceAll(
+      'className={accentClassName}',
+      "className={accentClassName == null ? 'zen-stroke-accent' : `zen-stroke-accent ${accentClassName}`}",
+    );
+
+  return { key, value, isLucide: true };
+}
+
+function generateIconFile(key, value, isLucide) {
   const componentName = `${key.replace(/[-\s]/g, '')}Icon`;
+  const lucideNote = isLucide ? '\n* Based on lucide (https://lucide.dev) — ISC License. See LICENSE-lucide.' : '';
 
   return `/*
 * NOTE: This file is auto generated
-* Do not edit manually.
+* Do not edit manually.${lucideNote}
 */
 import React from 'react';
 
@@ -59,30 +102,19 @@ export const ${componentName}: React.FC<${componentName}Props> = ({ accentClassN
 `;
 }
 
-async function exec() {
-  const files = glob.sync('./src/svg/*.svg');
-  console.log(`Processing ${files.length} SVG files...`);
-
-  // Ensure icons directory exists
-  const iconsDir = './src/icons';
-  if (!fs.existsSync(iconsDir)) {
-    fs.mkdirSync(iconsDir, { recursive: true });
-  }
-
-  // Process files in batches to reduce memory usage
+async function processInBatches(files, processor, result) {
   const batchSize = 10;
-  const result = [];
 
   for (let i = 0; i < files.length; i += batchSize) {
     const batch = files.slice(i, i + batchSize);
     console.log(`Processing batch ${Math.floor(i / batchSize) + 1}/${Math.ceil(files.length / batchSize)}`);
 
-    const batchResults = await Promise.all(batch.map(processSvgFile));
+    const batchResults = await Promise.all(batch.map(processor));
 
     // Generate individual icon files
-    batchResults.forEach(({ key, value }) => {
-      const iconContent = generateIconFile(key, value);
-      fs.writeFileSync(path.join(iconsDir, `${key}.tsx`), iconContent, 'utf8');
+    batchResults.forEach(({ key, value, isLucide }) => {
+      const iconContent = generateIconFile(key, value, isLucide);
+      fs.writeFileSync(path.join('./src/icons', `${key}.tsx`), iconContent, 'utf8');
     });
 
     result.push(...batchResults);
@@ -92,6 +124,42 @@ async function exec() {
       global.gc();
     }
   }
+}
+
+async function exec() {
+  // glob の `*` はサブディレクトリに降りないため、fill 系と lucide 系は確実に分離される
+  const fillFiles = glob.sync('./src/svg/*.svg');
+  const lucideFiles = glob.sync('./src/svg/lucide/*.svg');
+
+  const fillKeys = new Set(fillFiles.map((file) => path.basename(file, '.svg')));
+  const duplicatedKeys = lucideFiles.map((file) => path.basename(file, '.svg')).filter((key) => fillKeys.has(key));
+  if (duplicatedKeys.length > 0) {
+    throw new Error(`Duplicated icon names in src/svg/ and src/svg/lucide/: ${duplicatedKeys.join(', ')}`);
+  }
+
+  console.log(`Processing ${fillFiles.length + lucideFiles.length} SVG files...`);
+
+  // Ensure icons directory exists
+  const iconsDir = './src/icons';
+  if (!fs.existsSync(iconsDir)) {
+    fs.mkdirSync(iconsDir, { recursive: true });
+  }
+
+  const result = [];
+  await processInBatches(fillFiles, processSvgFile, result);
+  await processInBatches(lucideFiles, processLucideSvgFile, result);
+
+  // 決定的な生成順にする: 拡張子込みファイル名（`${key}.svg`）の降順。
+  // template.ejs が reverse するため、出力は「.svg 込みファイル名の昇順」（例: ai-agent が ai より先）になる
+  result.sort((a, b) => {
+    const aFile = `${a.key}.svg`;
+    const bFile = `${b.key}.svg`;
+
+    if (aFile < bFile) return 1;
+    if (aFile > bFile) return -1;
+
+    return 0;
+  });
 
   console.log('Generating main icon.tsx...');
   const output = await ejs.renderFile('./template.ejs', { result });
@@ -99,4 +167,7 @@ async function exec() {
   console.log('Icon generation completed!');
 }
 
-exec().catch(console.error);
+exec().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/component-ui/package.json
+++ b/packages/component-ui/package.json
@@ -29,6 +29,8 @@
     "@testing-library/react": "16.3.2",
     "@testing-library/user-event": "14.6.1",
     "hygen": "6.2.11",
+    "postcss": "8.5.25",
+    "tailwindcss": "3.4.19",
     "tsup": "8.5.1",
     "typescript": "5.9.3"
   },

--- a/packages/component-ui/src/icon/fill-bridge.test.ts
+++ b/packages/component-ui/src/icon/fill-bridge.test.ts
@@ -1,0 +1,100 @@
+import tailwindConfig from '@zenkigen-inc/component-config';
+import postcss from 'postcss';
+import type { Config } from 'tailwindcss';
+import tailwindcss from 'tailwindcss';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+/**
+ * fill-* ブリッジ（CSS 変数併出力）の回帰テスト
+ *
+ * component-config は core の fill plugin を無効化し、fill-* を「fill + --zen-icon-stroke」の
+ * 2 宣言を出す utility として再定義している（stroke 系アイコンへの着色ブリッジ）。
+ * このテストは preset の CSS 出力を実ビルドし、以下を担保する：
+ * - fill-* のあらゆる形（プレーン / variant / 任意値 / opacity modifier）で 2 宣言が併出力されること
+ * - .zen-stroke-icon / .zen-stroke-accent ルールが出力されること
+ * - safelist によりコンテンツ未使用でも fill-* と stroke-width 上書きが出力されること
+ */
+
+// variant・任意値・modifier は safelist では展開されないため raw コンテンツで与える。
+// プレーンな fill-* と zen-stroke-icon / stroke-width 上書きは safelist 経由の出力を検証する
+const RAW_CONTENT =
+  '<div class="hover:fill-icon01 group-hover:fill-supportError fill-[#12ab34] fill-red-red50/50"></div>';
+
+const buildCss = async (): Promise<string> => {
+  const result = await postcss([
+    tailwindcss({
+      presets: [tailwindConfig as unknown as Config],
+      content: [{ raw: RAW_CONTENT }],
+    } as Config),
+  ]).process('@tailwind utilities;', { from: 'fill-bridge.virtual.css' });
+
+  return result.css;
+};
+
+/** CSS 文字列から指定セレクタのルール本体（宣言部）を取り出す */
+const ruleOf = (css: string, selector: string): string => {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = css.match(new RegExp(`${escaped}\\s*\\{([^}]*)\\}`));
+
+  return match?.[1] ?? '';
+};
+
+let css = '';
+
+beforeAll(async () => {
+  css = await buildCss();
+}, 60_000);
+
+describe('fill-* ブリッジ（CSS 出力）', () => {
+  it('プレーンな fill-* に fill と --zen-icon-stroke が併出力されること（safelist 経由）', () => {
+    const rule = ruleOf(css, '.fill-icon01');
+    expect(rule).toContain('fill: #5c6366');
+    expect(rule).toContain('--zen-icon-stroke: #5c6366');
+  });
+
+  it('variant 付き fill-* にも併出力されること', () => {
+    const hoverRule = ruleOf(css, '.hover\\:fill-icon01:hover');
+    expect(hoverRule).toContain('--zen-icon-stroke: #5c6366');
+
+    const groupHoverRule = ruleOf(css, '.group:hover .group-hover\\:fill-supportError');
+    expect(groupHoverRule).toContain('fill: #c6244d');
+    expect(groupHoverRule).toContain('--zen-icon-stroke: #c6244d');
+  });
+
+  it('任意値の fill-[...] にも併出力されること', () => {
+    const rule = ruleOf(css, '.fill-\\[\\#12ab34\\]');
+    expect(rule).toContain('fill: #12ab34');
+    expect(rule).toContain('--zen-icon-stroke: #12ab34');
+  });
+
+  it('opacity modifier 付き fill-*/N にも併出力されること', () => {
+    const rule = ruleOf(css, '.fill-red-red50\\/50');
+    expect(rule).toContain('fill: rgb(217 43 87 / 0.5)');
+    expect(rule).toContain('--zen-icon-stroke: rgb(217 43 87 / 0.5)');
+  });
+
+  it('fill-none は --zen-icon-stroke: none になること（fill 系と同じ不可視挙動）', () => {
+    const rule = ruleOf(css, '.fill-none');
+    expect(rule).toContain('fill: none');
+    expect(rule).toContain('--zen-icon-stroke: none');
+  });
+
+  it('.zen-stroke-icon ルールが出力されること（safelist 経由）', () => {
+    const rule = ruleOf(css, '.zen-stroke-icon');
+    expect(rule).toContain('stroke: var(--zen-icon-stroke, currentColor)');
+  });
+
+  it('.zen-stroke-icon .zen-stroke-accent ルールが fill: none と stroke 変数参照を持つこと', () => {
+    const rule = ruleOf(css, '.zen-stroke-icon .zen-stroke-accent');
+    expect(rule).toContain('fill: none');
+    expect(rule).toContain('stroke: var(--zen-icon-stroke, currentColor)');
+  });
+
+  it('サイズ別 stroke-width 上書きが出力されること（safelist 経由）', () => {
+    for (const width of ['2.5', '2.25', '2', '1.75', '1.5']) {
+      const selector = `.\\[\\&_svg\\]\\:\\[stroke-width\\:${width.replace('.', '\\.')}\\] svg`;
+      const rule = ruleOf(css, selector);
+      expect(rule, `stroke-width:${width} の上書きルールが見つからない`).toContain(`stroke-width: ${width}`);
+    }
+  });
+});

--- a/packages/component-ui/src/icon/fill-bridge.test.ts
+++ b/packages/component-ui/src/icon/fill-bridge.test.ts
@@ -91,7 +91,7 @@ describe('fill-* ブリッジ（CSS 出力）', () => {
   });
 
   it('サイズ別 stroke-width 上書きが出力されること（safelist 経由）', () => {
-    for (const width of ['2.5', '2.25', '2', '1.75', '1.5']) {
+    for (const width of ['2.5', '2.35', '2', '1.65', '1.4']) {
       const selector = `.\\[\\&_svg\\]\\:\\[stroke-width\\:${width.replace('.', '\\.')}\\] svg`;
       const rule = ruleOf(css, selector);
       expect(rule, `stroke-width:${width} の上書きルールが見つからない`).toContain(`stroke-width: ${width}`);

--- a/packages/component-ui/src/icon/icon.test.tsx
+++ b/packages/component-ui/src/icon/icon.test.tsx
@@ -1,0 +1,120 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { Icon } from './icon';
+
+/**
+ * Icon テストについて
+ *
+ * テストの構成：
+ * - 基本表示：レンダリング、aria-label
+ * - サイズ：5 サイズの幅・高さと stroke-width 上書きクラス
+ * - 色：color プロパティ、未指定時、className 併用
+ * - 無効状態：isDisabled の優先
+ * - アクセントカラー：accent 対応アイコン全件の accentClassName 反映
+ *   （lucide 置き換え時に accent 付与漏れがあると accentColor が黙って無効化するため、全件を回帰網とする）
+ */
+
+/** accent 対応アイコン（SVG に class="accent" を持つ全件）。置き換え作業で減っていないことを担保する */
+const ACCENT_ICON_NAMES = [
+  'ai-agent',
+  'calendar-attention',
+  'calendar-check',
+  'calendar-minus',
+  'calendar-today',
+  'mic',
+  'signal-low',
+  'signal-off',
+  'volume-off',
+] as const;
+
+describe('Icon', () => {
+  describe('基本表示', () => {
+    it('正常にレンダリングされ、svg が表示されること', () => {
+      render(<Icon name="add" />);
+      const icon = screen.getByRole('img', { name: 'add' });
+      expect(icon).toBeInTheDocument();
+      expect(icon.tagName.toLowerCase()).toBe('svg');
+    });
+
+    it('ケバブケース名の aria-label はキャメルケース化された名前になること（既存の生成仕様）', () => {
+      // codegen.cjs の属性変換 regex が aria-label の値まで変換する既知の挙動。
+      // 生成物 diff ゼロを維持するため、この挙動をそのまま固定する
+      render(<Icon name="angle-down" />);
+      expect(screen.getByRole('img', { name: 'angleDown' })).toBeInTheDocument();
+    });
+  });
+
+  describe('サイズ', () => {
+    it.each([
+      ['x-small', ['w-3', 'h-3', '[&_svg]:[stroke-width:2.5]']],
+      ['small', ['w-4', 'h-4', '[&_svg]:[stroke-width:2.25]']],
+      ['medium', ['w-6', 'h-6', '[&_svg]:[stroke-width:2]']],
+      ['large', ['w-8', 'h-8', '[&_svg]:[stroke-width:1.75]']],
+      ['x-large', ['w-10', 'h-10', '[&_svg]:[stroke-width:1.5]']],
+    ] as const)('size="%s" の場合、幅・高さと stroke-width 上書きクラスが付与されること', (size, classes) => {
+      render(<Icon name="add" size={size} />);
+      const wrapper = screen.getByRole('img').parentElement;
+      expect(wrapper).toHaveClass(...classes);
+    });
+
+    it('size 未指定の場合、medium のクラスが付与されること', () => {
+      render(<Icon name="add" />);
+      const wrapper = screen.getByRole('img').parentElement;
+      expect(wrapper).toHaveClass('w-6', 'h-6', '[&_svg]:[stroke-width:2]');
+    });
+  });
+
+  describe('色', () => {
+    it('color を指定した場合、fill-* クラスが付与されること', () => {
+      render(<Icon name="add" color="icon01" />);
+      const wrapper = screen.getByRole('img').parentElement;
+      expect(wrapper).toHaveClass('fill-icon01');
+    });
+
+    it('color 未指定の場合、fill-* クラスが付与されないこと', () => {
+      render(<Icon name="add" />);
+      const wrapper = screen.getByRole('img').parentElement;
+      expect(wrapper?.className).not.toMatch(/fill-/);
+    });
+
+    it('className を併用できること', () => {
+      render(<Icon name="add" color="icon01" className="mt-1" />);
+      const wrapper = screen.getByRole('img').parentElement;
+      expect(wrapper).toHaveClass('fill-icon01', 'mt-1');
+    });
+  });
+
+  describe('無効状態', () => {
+    it('isDisabled=true の場合、color より fill-disabled01 が優先されること', () => {
+      render(<Icon name="add" color="icon01" isDisabled />);
+      const wrapper = screen.getByRole('img').parentElement;
+      expect(wrapper).toHaveClass('fill-disabled01');
+      expect(wrapper).not.toHaveClass('fill-icon01');
+    });
+  });
+
+  describe('アクセントカラー', () => {
+    it.each(ACCENT_ICON_NAMES.map((name) => [name] as const))(
+      'accent 対応アイコン %s が accentColor のクラスを accent 要素に反映すること',
+      (name) => {
+        render(<Icon name={name} accentColor="supportError" />);
+        const icon = screen.getByRole('img');
+        expect(icon.querySelector('.fill-supportError')).not.toBeNull();
+      },
+    );
+
+    it('isDisabled=true の場合、accentColor が反映されないこと', () => {
+      render(<Icon name="mic" accentColor="supportError" isDisabled />);
+      const icon = screen.getByRole('img');
+      expect(icon.querySelector('.fill-supportError')).toBeNull();
+    });
+
+    it('accent 要素を持たないアイコンでは accentColor を指定しても何も起きないこと', () => {
+      render(<Icon name="add" accentColor="supportError" />);
+      const icon = screen.getByRole('img');
+      expect(icon.querySelector('.fill-supportError')).toBeNull();
+    });
+  });
+});

--- a/packages/component-ui/src/icon/icon.test.tsx
+++ b/packages/component-ui/src/icon/icon.test.tsx
@@ -49,10 +49,10 @@ describe('Icon', () => {
   describe('サイズ', () => {
     it.each([
       ['x-small', ['w-3', 'h-3', '[&_svg]:[stroke-width:2.5]']],
-      ['small', ['w-4', 'h-4', '[&_svg]:[stroke-width:2.25]']],
+      ['small', ['w-4', 'h-4', '[&_svg]:[stroke-width:2.35]']],
       ['medium', ['w-6', 'h-6', '[&_svg]:[stroke-width:2]']],
-      ['large', ['w-8', 'h-8', '[&_svg]:[stroke-width:1.75]']],
-      ['x-large', ['w-10', 'h-10', '[&_svg]:[stroke-width:1.5]']],
+      ['large', ['w-8', 'h-8', '[&_svg]:[stroke-width:1.65]']],
+      ['x-large', ['w-10', 'h-10', '[&_svg]:[stroke-width:1.4]']],
     ] as const)('size="%s" の場合、幅・高さと stroke-width 上書きクラスが付与されること', (size, classes) => {
       render(<Icon name="add" size={size} />);
       const wrapper = screen.getByRole('img').parentElement;

--- a/packages/component-ui/src/icon/icon.tsx
+++ b/packages/component-ui/src/icon/icon.tsx
@@ -21,11 +21,13 @@ export const Icon = ({ size = 'medium', isDisabled = false, ...props }: Props) =
     {
       'fill-disabled01': isDisabled,
       [`fill-${props.color}`]: !isDisabled && props.color != null,
-      'w-3 h-3': size === 'x-small',
-      'w-4 h-4': size === 'small',
-      'w-6 h-6': size === 'medium',
-      'w-8 h-8': size === 'large',
-      'w-10 h-10': size === 'x-large',
+      // stroke-width はサイズ別に上書きする（stroke 系アイコンは viewBox 24 基準で一様スケールされるため、
+      // 小サイズでは太く・大サイズでは細くして実効線幅を補正する。fill 系アイコンは stroke 不使用のため無害）
+      'w-3 h-3 [&_svg]:[stroke-width:2.5]': size === 'x-small',
+      'w-4 h-4 [&_svg]:[stroke-width:2.25]': size === 'small',
+      'w-6 h-6 [&_svg]:[stroke-width:2]': size === 'medium',
+      'w-8 h-8 [&_svg]:[stroke-width:1.75]': size === 'large',
+      'w-10 h-10 [&_svg]:[stroke-width:1.5]': size === 'x-large',
     },
     props.className,
   );

--- a/packages/component-ui/src/icon/icon.tsx
+++ b/packages/component-ui/src/icon/icon.tsx
@@ -24,10 +24,10 @@ export const Icon = ({ size = 'medium', isDisabled = false, ...props }: Props) =
       // stroke-width はサイズ別に上書きする（stroke 系アイコンは viewBox 24 基準で一様スケールされるため、
       // 小サイズでは太く・大サイズでは細くして実効線幅を補正する。fill 系アイコンは stroke 不使用のため無害）
       'w-3 h-3 [&_svg]:[stroke-width:2.5]': size === 'x-small',
-      'w-4 h-4 [&_svg]:[stroke-width:2.25]': size === 'small',
+      'w-4 h-4 [&_svg]:[stroke-width:2.35]': size === 'small',
       'w-6 h-6 [&_svg]:[stroke-width:2]': size === 'medium',
-      'w-8 h-8 [&_svg]:[stroke-width:1.75]': size === 'large',
-      'w-10 h-10 [&_svg]:[stroke-width:1.5]': size === 'x-large',
+      'w-8 h-8 [&_svg]:[stroke-width:1.65]': size === 'large',
+      'w-10 h-10 [&_svg]:[stroke-width:1.4]': size === 'x-large',
     },
     props.className,
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -3685,7 +3685,9 @@ __metadata:
     "@zenkigen-inc/component-theme": "workspace:*"
     clsx: "npm:2.1.1"
     hygen: "npm:6.2.11"
+    postcss: "npm:8.5.25"
     react-day-picker: "npm:9.14.0"
+    tailwindcss: "npm:3.4.19"
     tsup: "npm:8.5.1"
     typescript: "npm:5.9.3"
   peerDependencies:


### PR DESCRIPTION
> [!NOTE]
> - **この PR は視覚変化ゼロ**（既存アイコンの生成物はバイト一致、CSS 出力は fill-* への 1 宣言追加のみ）。Chromatic 差分ゼロが受け入れ条件です。
> - アイコンを lucide の stroke 線画に差し替える PR（90 件置換）がこの PR にスタックされます。本 PR は差し替えを可能にする基盤のみで、単体で 1.x minor としてリリース可能です。

## 概要

アイコンの lucide 置き換え（fill 塗り → stroke 線画）に向けて、stroke 系アイコンを既存パイプラインで扱えるようにする基盤を追加します。既存 142 アイコンの見た目・生成物・CSS 出力は変わりません。

## 設計判断

**着色 = CSS 変数ブリッジ方式。** 利用側には `<Icon color>` prop 以外に `className="fill-*"` 直渡し・親ラッパーへの `fill-*` 付与・`group-hover:fill-*` 等の着色経路が実在するため、共有 preset で `fill-*` ユーティリティを再定義し `fill` + `--zen-icon-stroke` CSS 変数を併出力します。CSS 変数は DOM を継承するため、fill-* がどの要素に付いていても stroke 系アイコンに同じ解決規則で色が届きます（利用側のコード修正ゼロで完全後方互換）。

- core の `fill` plugin と同一シグネチャ（`flattenColorPalette` + `toColorValue` + `type: ['color', 'any']`）で再実装しているため、variant・任意値・opacity modifier を含め既存出力と一致します
- accent 対応は accent path に `zen-stroke-accent` marker class + `.zen-stroke-icon .zen-stroke-accent { fill: none; stroke: var(--zen-icon-stroke, currentColor) }` 子孫ルール。specificity (0,2,0) で fill-* クラスによる塗り事故を防ぎつつ、path 自身のスコープで変数を解決させて accent 色を stroke に届けます
- **サイズ別 stroke-width 補正**: SVG は viewBox 24 基準で一様スケールされるため、Icon の size 分岐で stroke-width を上書きします（x-small 2.5 / small 2.25 / medium 2 / large 1.75 / x-large 1.5。初期値は仮値でデザイナー確認後に調整予定）

## 変更内容

### 変更ファイル

| ファイル | 内容 |
|---|---|
| `packages/component-icons/codegen.cjs` | `src/svg/lucide/` の stroke 系分岐（stroke 属性保持・`zen-stroke-icon` 付与）、重複キー検出、生成順の決定的ソート、エラー時 exit 1 |
| `packages/component-config/src/tailwind-config.ts` | core `fill` plugin 無効化 + matchUtilities 再定義（CSS 変数併出力）+ `.zen-stroke-icon` ルール + safelist 追加 |
| `packages/component-config/src/types/tailwindcss-internals.d.ts` | tailwindcss 内部ユーティリティの型宣言（新規） |
| `packages/component-ui/src/icon/icon.tsx` | サイズ別 `[&_svg]:[stroke-width:X]` クラス追加（着色ロジック無変更） |
| `packages/component-ui/src/icon/icon.test.tsx` | Icon 単体テスト新設（accent 対応 9 アイコン全件の回帰網を含む） |
| `packages/component-ui/src/icon/fill-bridge.test.ts` | preset の CSS 出力を実ビルドして検証する回帰テスト（新規） |
| `packages/component-ui/package.json` | テスト用 devDeps（tailwindcss / postcss、固定バージョン） |

## 影響範囲

- **視覚変化・破壊的変更なし**。`yarn generate` 後の既存生成物はバイト一致（`git diff --exit-code` で検証）
- CSS 出力は構造比較で「fill-* 全ルールへの `--zen-icon-stroke` 1 宣言追加 + `.zen-stroke-icon` 系 2 ルールと safelist 由来 5 セレクタの純増」のみであることを機械検証済み（既存宣言の変更・削除なし）
- この時点では `src/svg/lucide/` が空のため、codegen の新分岐・`.zen-stroke-icon` ルールはどの既存アイコンにも作用しません

## スコープ外 / 非ゴール

- アイコンの実差し替え（置換 90 件）はスタックする次の PR で実施
- codegen 既知の aria-label 値の camelCase 化バグは温存（生成物 diff ゼロ維持のため。別 PR で対応予定）

## テスト観点

- Icon: 5 サイズの幅・高さ + stroke-width 上書きクラス / `color` → `fill-*` / `isDisabled` 優先 / accent 対応 9 アイコン全件の `accentClassName` 反映（差し替え時の accent 付与漏れ＝黙って無効化への回帰網）
- fill ブリッジ: プレーン / variant / 任意値 `fill-[#hex]` / opacity modifier / `fill-none` の全形で `fill` + `--zen-icon-stroke` 併出力、`.zen-stroke-icon` ルール、safelist 経由の出力

## テスト手順

- [ ] Chromatic の差分がゼロであること（本 PR の受け入れ条件）
- [ ] Storybook `Components/Icon` で既存アイコンの表示に変化がないこと

## 実行したコマンド

- `yarn build:all` — OK
- `yarn lint` — OK
- `yarn type-check` — OK
- `yarn test:ci` — 全テスト通過（825 passed, 2 skipped）
- `yarn workspace @zenkigen-inc/component-icons generate` 後の `git diff --exit-code packages/component-icons/src` — diff ゼロ
- `yarn install --immutable` — OK
