### PR TITLE
328｜feat(component-ui): Replace angle-small toggles with angle chevrons

### DIFF
--- a/packages/component-ui/src/dropdown/dropdown.tsx
+++ b/packages/component-ui/src/dropdown/dropdown.tsx
@@ -139,10 +139,7 @@ export function Dropdown({
             {target}
             {!isArrowHidden && (
               <div className="ml-2 flex items-center fill-icon01">
-                <Icon
-                  name={isVisible ? 'angle-small-up' : 'angle-small-down'}
-                  size={size === 'large' ? 'medium' : 'small'}
-                />
+                <Icon name={isVisible ? 'angle-up' : 'angle-down'} size={size === 'large' ? 'medium' : 'small'} />
               </div>
             )}
           </button>
@@ -156,7 +153,7 @@ export function Dropdown({
             <span className={labelClasses}>{label}</span>
             {!isArrowHidden && (
               <div className="ml-auto flex items-center">
-                <Icon name={isVisible ? 'angle-small-up' : 'angle-small-down'} size="small" />
+                <Icon name={isVisible ? 'angle-up' : 'angle-down'} size="small" />
               </div>
             )}
           </button>

--- a/packages/component-ui/src/select-sort/select-sort.tsx
+++ b/packages/component-ui/src/select-sort/select-sort.tsx
@@ -100,10 +100,7 @@ export function SelectSort({
               size={size === 'large' ? 'medium' : 'small'}
             />
           ) : (
-            <Icon
-              name={isOptionListOpen ? 'angle-small-up' : 'angle-small-down'}
-              size={size === 'large' ? 'medium' : 'small'}
-            />
+            <Icon name={isOptionListOpen ? 'angle-up' : 'angle-down'} size={size === 'large' ? 'medium' : 'small'} />
           )}
         </div>
       </button>

--- a/packages/component-ui/src/select/select.test.tsx
+++ b/packages/component-ui/src/select/select.test.tsx
@@ -528,7 +528,7 @@ describe('Select', () => {
       render(<SelectTestComponent />);
       const selectButton = screen.getByRole('button');
 
-      const downIcon = selectButton.querySelector('[aria-label="angleSmallDown"]');
+      const downIcon = selectButton.querySelector('[aria-label="angleDown"]');
       expect(downIcon).toBeInTheDocument();
     });
 
@@ -538,10 +538,10 @@ describe('Select', () => {
 
       fireEvent.click(selectButton);
 
-      const upIcon = selectButton.querySelector('[aria-label="angleSmallUp"]');
+      const upIcon = selectButton.querySelector('[aria-label="angleUp"]');
       expect(upIcon).toBeInTheDocument();
 
-      const downIcon = selectButton.querySelector('[aria-label="angleSmallDown"]');
+      const downIcon = selectButton.querySelector('[aria-label="angleDown"]');
       expect(downIcon).not.toBeInTheDocument();
     });
   });

--- a/packages/component-ui/src/select/select.tsx
+++ b/packages/component-ui/src/select/select.tsx
@@ -182,10 +182,7 @@ export function Select({
             <div className="truncate">{selectedOption ? selectedOption.label : placeholder != null && placeholder}</div>
           </div>
           <div className="ml-auto flex items-center">
-            <Icon
-              name={isOptionListOpen ? 'angle-small-up' : 'angle-small-down'}
-              size={size === 'large' ? 'medium' : 'small'}
-            />
+            <Icon name={isOptionListOpen ? 'angle-up' : 'angle-down'} size={size === 'large' ? 'medium' : 'small'} />
           </div>
         </button>
         {isOptionListOpen && !isDisabled && (

--- a/packages/component-ui/src/sort-button/sort-button.test.tsx
+++ b/packages/component-ui/src/sort-button/sort-button.test.tsx
@@ -121,10 +121,10 @@ describe('SortButton', () => {
   });
 
   describe('ソート状態とアイコン表示', () => {
-    it('sortOrder=nullの場合にangle-small-downアイコンが表示されること', () => {
+    it('sortOrder=nullの場合にangle-downアイコンが表示されること', () => {
       render(<SortButton label="テストラベル" sortOrder={null} aria-label="テストボタン" data-testid="sort-button" />);
       const button = screen.getByTestId('sort-button');
-      const iconSvg = button.querySelector('span svg[aria-label="angleSmallDown"]');
+      const iconSvg = button.querySelector('span svg[aria-label="angleDown"]');
       expect(iconSvg).toBeInTheDocument();
       // アイコンコンポーネントが存在することを確認
       expect(button.querySelector('span')).toHaveClass('inline-block', 'shrink-0');
@@ -179,9 +179,9 @@ describe('SortButton', () => {
         <SortButton label="テストラベル" sortOrder={null} aria-label="テストボタン" data-testid="sort-button" />,
       );
 
-      // 初期状態（null）でangle-small-downアイコンが表示
+      // 初期状態（null）でangle-downアイコンが表示
       let button = screen.getByTestId('sort-button');
-      expect(button.querySelector('span svg[aria-label="angleSmallDown"]')).toBeInTheDocument();
+      expect(button.querySelector('span svg[aria-label="angleDown"]')).toBeInTheDocument();
       expect(button.querySelector('span svg[aria-label="arrowUp"]')).not.toBeInTheDocument();
       expect(button.querySelector('span svg[aria-label="arrowDown"]')).not.toBeInTheDocument();
 
@@ -191,7 +191,7 @@ describe('SortButton', () => {
       );
       button = screen.getByTestId('sort-button');
       expect(button.querySelector('span svg[aria-label="arrowUp"]')).toBeInTheDocument();
-      expect(button.querySelector('span svg[aria-label="angleSmallDown"]')).not.toBeInTheDocument();
+      expect(button.querySelector('span svg[aria-label="angleDown"]')).not.toBeInTheDocument();
       expect(button.querySelector('span svg[aria-label="arrowDown"]')).not.toBeInTheDocument();
 
       // descendに変更してarrow-downアイコンが表示
@@ -200,7 +200,7 @@ describe('SortButton', () => {
       );
       button = screen.getByTestId('sort-button');
       expect(button.querySelector('span svg[aria-label="arrowDown"]')).toBeInTheDocument();
-      expect(button.querySelector('span svg[aria-label="angleSmallDown"]')).not.toBeInTheDocument();
+      expect(button.querySelector('span svg[aria-label="angleDown"]')).not.toBeInTheDocument();
       expect(button.querySelector('span svg[aria-label="arrowUp"]')).not.toBeInTheDocument();
     });
   });

--- a/packages/component-ui/src/sort-button/sort-button.tsx
+++ b/packages/component-ui/src/sort-button/sort-button.tsx
@@ -40,7 +40,7 @@ export function SortButton({
     if (sortOrder === 'ascend') return 'arrow-up';
     if (sortOrder === 'descend') return 'arrow-down';
 
-    return 'angle-small-down';
+    return 'angle-down';
   };
 
   const wrapperClasses = clsx('relative flex shrink-0 items-center gap-1 rounded', {


### PR DESCRIPTION
> [!NOTE]
> - この PR は #615 にスタックしています（base: `feature/lucide-icon-migration`）。#615 がマージされると base は自動的に切り替わります。
> - 開閉トグルの見た目のみの変更です（レイアウト・API 変更なし）。視覚差分は Chromatic でレビューしてください。

## 概要

Dropdown / Select / SelectSort / SortButton の開閉トグル（計 5 箇所）で内部使用していた `angle-small-up` / `angle-small-down` を、`angle-up` / `angle-down`（lucide chevron）に置き換えます。Combobox のトグルは元から `angle-*` を使用しており、この変更で**開閉トグルの表現が全コンポーネントで統一**されます。

## 変更前後の対応表

| コンポーネント | 箇所 | 変更前 | 変更後 | Icon サイズ（変更なし） |
|---|---|---|---|---|
| Dropdown | `target` 指定時の開閉矢印 | `angle-small-up` / `angle-small-down` | `angle-up` / `angle-down` | small（large 時 medium） |
| Dropdown | label ボタンの開閉矢印 | `angle-small-up` / `angle-small-down` | `angle-up` / `angle-down` | small 固定 |
| Select | 開閉矢印 | `angle-small-up` / `angle-small-down` | `angle-up` / `angle-down` | small（large 時 medium） |
| SelectSort | 開閉矢印 | `angle-small-up` / `angle-small-down` | `angle-up` / `angle-down` | small（large 時 medium） |
| SortButton | 未ソート時のアイコン | `angle-small-down` | `angle-down` | small（large 時 medium） |

見た目の変化: `angle-small-*` は小型 fill グリフ（幅 11.8/24）、`angle-*` は lucide stroke chevron（幅 14/24）のため、**同じ Icon サイズでもトグルが約 2 割大きく**なります。

## 設計判断

- **Icon サイズは据え置き**（上表のとおり）。Icon の占有ボックスが変わらないため、ボタン高さ・`ml-auto` の右端配置などレイアウトへの影響はゼロ
- サイズ 1 段下げでの optical 合わせ込み（グリフ幅がほぼ揃う）も検討したが、占有ボックスが縮んでレイアウト差分が出るため不採用。大きさ感は Chromatic で確認し、必要なら調整する
- `angle-small-up` / `angle-small-down` 自体は IconName に残す（独自維持判定のまま。利用側アプリの直接指定に影響なし。内部使用者はこの変更でゼロになる）

## 変更内容

| ファイル | 内容 |
|---|---|
| `packages/component-ui/src/dropdown/dropdown.tsx` | 開閉トグル 2 箇所（target 指定時 / label ボタン）の name 変更 |
| `packages/component-ui/src/select/select.tsx` | 開閉トグルの name 変更 |
| `packages/component-ui/src/select-sort/select-sort.tsx` | 開閉トグルの name 変更 |
| `packages/component-ui/src/sort-button/sort-button.tsx` | 未ソート時アイコンの name 変更 |
| `packages/component-ui/src/select/select.test.tsx`, `sort-button.test.tsx` | aria-label 参照の追従（`angleSmallDown` → `angleDown` 等） |

## 影響範囲

- **視覚のみの変更**（4 コンポーネントの開閉トグルが小型 fill チェブロン → lucide stroke chevron に）
- API・レイアウト・利用側コードへの影響なし

## スクリーンショット / Storybook

- `Components/Select` → `Base`（全サイズ × variant で新トグルを確認可能）
- `Components/Dropdown` / `Components/SelectSort` / `Components/SortButton` の各ストーリー

## テスト観点

- SortButton: 未ソート時に `angle-down` が表示され、ソート順で `arrow-up` / `arrow-down` に切り替わること
- Select: 開閉状態で `angle-down` / `angle-up` が切り替わること

## テスト手順

- [ ] Chromatic で差分が 4 コンポーネントの開閉トグルのみであること
- [ ] Select / Dropdown を開閉してトグルの向きが正しく切り替わること

## 実行したコマンド

- `yarn build:all` — OK
- `yarn lint` — OK
- `yarn type-check` — OK
- `yarn test:ci` — 全テスト通過（823 passed, 2 skipped）